### PR TITLE
Switch to initial_pvi in the error report notebook

### DIFF
--- a/reports/PREOPS-prompt-error-msgs.ipynb
+++ b/reports/PREOPS-prompt-error-msgs.ipynb
@@ -55,12 +55,12 @@
     "log_visit_detector = set([(x.dataId['exposure'], x.dataId['detector']) for x in b.registry.queryDatasets(\"isr_log\")])\n",
     "print(\"Number of ISRs attempted: {:d}\".format(len(log_visit_detector)))\n",
     "\n",
-    "calexp_visit_detector = set([(x.dataId['visit'], x.dataId['detector']) for x in b.registry.queryDatasets(\"initial_pvi\")])\n",
-    "print(\"Number of successful initial_pvi attempted: {:d}\".format(len(calexp_visit_detector)))\n",
+    "pvi_visit_detector = set([(x.dataId['visit'], x.dataId['detector']) for x in b.registry.queryDatasets(\"initial_pvi\")])\n",
+    "print(\"Number of successful initial_pvi attempted: {:d}\".format(len(pvi_visit_detector)))\n",
     "\n",
-    "missing_calexps = set(log_visit_detector - calexp_visit_detector)\n",
-    "missing_visits = [x[0] for x in missing_calexps]\n",
-    "print(\"Number of unsuccessful processCcd attempts (no resulting initial_pvi): {:d}\".format(len(missing_calexps)))"
+    "missing_pvis = set(log_visit_detector - pvi_visit_detector)\n",
+    "missing_visits = [x[0] for x in missing_pvis]\n",
+    "print(\"Number of unsuccessful processCcd attempts (no resulting initial_pvi): {:d}\".format(len(missing_pvis)))"
    ]
   },
   {
@@ -75,7 +75,7 @@
     "log_dataset_types_visit = [\"calibrateImage_log\"]\n",
     "\n",
     "error_summaries = []\n",
-    "for visit, detector in missing_calexps:\n",
+    "for visit, detector in missing_pvis:\n",
     "\n",
     "    visit_errors = []\n",
     "    \n",

--- a/reports/PREOPS-prompt-error-msgs.ipynb
+++ b/reports/PREOPS-prompt-error-msgs.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "day_obs = \"2024-02-29\"\n",
+    "day_obs = \"2024-03-19\"\n",
     "instrument = \"LATISS\""
    ]
   },
@@ -55,12 +55,12 @@
     "log_visit_detector = set([(x.dataId['exposure'], x.dataId['detector']) for x in b.registry.queryDatasets(\"isr_log\")])\n",
     "print(\"Number of ISRs attempted: {:d}\".format(len(log_visit_detector)))\n",
     "\n",
-    "calexp_visit_detector = set([(x.dataId['visit'], x.dataId['detector']) for x in b.registry.queryDatasets(\"calexp\")])\n",
-    "print(\"Number of successful calexps attempted: {:d}\".format(len(calexp_visit_detector)))\n",
+    "calexp_visit_detector = set([(x.dataId['visit'], x.dataId['detector']) for x in b.registry.queryDatasets(\"initial_pvi\")])\n",
+    "print(\"Number of successful initial_pvi attempted: {:d}\".format(len(calexp_visit_detector)))\n",
     "\n",
     "missing_calexps = set(log_visit_detector - calexp_visit_detector)\n",
     "missing_visits = [x[0] for x in missing_calexps]\n",
-    "print(\"Number of unsuccessful processCcd attempts (no resulting calexp): {:d}\".format(len(missing_calexps)))"
+    "print(\"Number of unsuccessful processCcd attempts (no resulting initial_pvi): {:d}\".format(len(missing_calexps)))"
    ]
   },
   {
@@ -72,7 +72,7 @@
    "source": [
     "\n",
     "log_dataset_types_exposure = [\"isr_log\"]\n",
-    "log_dataset_types_visit = [\"characterizeImage_log\", \"calibrate_log\"]\n",
+    "log_dataset_types_visit = [\"calibrateImage_log\"]\n",
     "\n",
     "error_summaries = []\n",
     "for visit, detector in missing_calexps:\n",

--- a/reports/PREOPS-prompt-error-msgs.yaml
+++ b/reports/PREOPS-prompt-error-msgs.yaml
@@ -4,7 +4,7 @@ parameters:
   day_obs:
     type: string
     description: Observation Night (YYYY-MM-DD)
-    default: "2024-02-29"
+    default: "2024-03-19"
   instrument:
     type: string
     description: Instrument


### PR DESCRIPTION
On day_obs 2024-03-07, Prompt Processing LATISS prod started to use the `w_2024_10 ` stack, which has `calibrateImage` as the default in ApPipe. 