### PR TITLE
Updated TargetReport to use a range of dates

### DIFF
--- a/reports/TargetReport.ipynb
+++ b/reports/TargetReport.ipynb
@@ -14,54 +14,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "3ce8dfcc-d745-4fc3-ad39-6b2d5e0e2be6",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:53.072919Z",
+     "iopub.status.busy": "2024-10-28T21:18:53.072789Z",
+     "iopub.status.idle": "2024-10-28T21:18:53.075346Z",
+     "shell.execute_reply": "2024-10-28T21:18:53.074997Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:53.072905Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "instrument = 'LATISS'\n",
-    "repo = '/repo/embargo'\n",
-    "day_obs = '2024-08-07'\n",
-    "collection = 'LATISS/prompt/output-2024-08-07'\n",
-    "collection_sky = 'LATISS/runs/AUXTEL_DRP_IMAGING_20230509_20240513/w_2024_20/PREOPS-5146'\n",
-    "skymap_name = 'latiss_v1'\n",
+    "instrument = 'LSSTComCam'\n",
+    "repo = 'embargo_new'\n",
+    "day_obs_start = '2024-10-24'\n",
+    "day_obs_end = 'TODAY'\n",
+    "collection = 'LSSTComCam/nightlyValidation'\n",
+    "collection_sky = 'LSSTComCamSim/runs/DRP/OR4/w_2024_25/DM-45066'\n",
+    "skymap_name = 'ops_rehersal_prep_2k_v1'\n",
     "col_sciprog = 'science_program'\n",
     "col_target = 'target'\n",
     "col_filter = 'filter'\n",
-    "col_id = 'id'\n"
+    "col_id = 'id'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "18ecc10d-2938-440e-8d5f-84dbfde6cac7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from datetime import datetime\n",
-    "\n",
-    "# Convert the string to a datetime object\n",
-    "day_obs_obj = datetime.strptime(day_obs, '%Y-%m-%d')\n",
-    "\n",
-    "# Format the datetime object as an integer\n",
-    "day_obs_int = int(day_obs_obj.strftime('%Y%m%d'))\n",
-    "\n",
-    "print(day_obs_int)  # Output: 20240807\n",
-    "\n",
-    "day_obs = day_obs_int"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "08b3556a",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:53.095967Z",
+     "iopub.status.busy": "2024-10-28T21:18:53.095825Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.442131Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.441709Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:53.095954Z"
+    },
     "tags": []
    },
    "outputs": [],
    "source": [
     "\n",
-    "## 1.2 Import packages\n",
+    "## 1.1 Import packages\n",
     "\n",
     "import sys\n",
     "import os\n",
@@ -86,14 +82,62 @@
     "from astropy.io import fits\n",
     "from astropy.time import Time\n",
     "\n",
+    "from datetime import datetime\n",
+    "from datetime import date\n",
+    "\n",
     "import warnings"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
+   "id": "0fd9f3fe-be33-4e41-915e-0594018f74c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.442997Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.442852Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.446441Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.446100Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.442978Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "# 1.2 Convert day_obs_start and day_obs_end to integers...\n",
+    "\n",
+    "# Convert the date_obs_start string to a datetime object\n",
+    "if day_obs_start.lower() == \"today\":\n",
+    "    day_obs_start = datetime.strptime(date.today().strftime(\"%Y-%m-%d\"), '%Y-%m-%d')\n",
+    "else:\n",
+    "    day_obs_start = datetime.strptime(day_obs_start, '%Y-%m-%d')\n",
+    "# Convert the date_obs_start datetime object to an integer\n",
+    "day_obs_start = int(day_obs_start.strftime('%Y%m%d'))\n",
+    "#print(\"Start date is: \", day_obs_start)\n",
+    "\n",
+    "# Convert the date_obs_end string to a datetime object\n",
+    "if day_obs_end.lower() == \"today\":\n",
+    "    day_obs_end = datetime.strptime(date.today().strftime(\"%Y-%m-%d\"), '%Y-%m-%d')\n",
+    "else:\n",
+    "    day_obs_end = datetime.strptime(day_obs_end, '%Y-%m-%d')\n",
+    "# Convert the date_obs_end datetime object to an integer\n",
+    "day_obs_end = int(day_obs_end.strftime('%Y%m%d'))\n",
+    "#print(\"End date is: \", day_obs_end)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "2fd7808f-8111-4c23-8735-5a8fbc26b67f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.447167Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.446884Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.451974Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.451623Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.447152Z"
+    }
+   },
    "outputs": [],
    "source": [
     "## 1.3 Define functions and parameters\n",
@@ -135,9 +179,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "48629971-c159-4e22-af48-f1a7afb61839",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.452939Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.452759Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.457998Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.457643Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.452925Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -175,9 +227,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "7ecfadfc-7a02-4634-a264-cfb4c0e40762",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.458557Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.458436Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.463616Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.463272Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.458545Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -215,9 +275,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "b9ef46fb-8f50-49d0-bbae-0a2662baa7d5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.464210Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.464086Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.471270Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.470958Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.464197Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -286,9 +354,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "45b41be8-c1e3-428c-9aa2-ab6e2f46afd6",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.471813Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.471691Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.476494Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.476189Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.471800Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -314,9 +390,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "06739927-d21e-449c-ac6a-89e0118d14ad",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.477018Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.476899Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.480737Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.480446Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.477006Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -344,9 +428,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "fff24f55-6d1c-4f18-9f60-99431c2a5336",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.481318Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.481205Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.485674Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.485397Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.481306Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -370,9 +462,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "83b16bb4-cd15-402f-81c2-7b7193df0630",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.487092Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.486971Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.489623Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.489341Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.487081Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -399,9 +499,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "c81c9f13-1b9a-4d60-84a8-50368873fb0e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.490141Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.490026Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.494002Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.493707Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.490129Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -414,9 +522,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "4c6ba6a7-c940-4c0c-a513-f9a4a1dab1b8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.494515Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.494402Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.498354Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.498017Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.494504Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -426,9 +542,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "07168a2e",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.498925Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.498802Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.612105Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.611675Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.498913Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -440,9 +563,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "0bff8f23-c35c-4b72-b9f5-7d32b432ac22",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.612829Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.612648Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.615547Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.615201Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.612815Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -458,9 +589,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "bab9ef6c-ced2-4d09-b67a-419f1b33d4a8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.616322Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.616018Z",
+     "iopub.status.idle": "2024-10-28T21:18:55.623418Z",
+     "shell.execute_reply": "2024-10-28T21:18:55.623069Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.616308Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -505,10 +644,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "81254df0-8ec8-4515-b2dc-743f3cceca16",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:55.624056Z",
+     "iopub.status.busy": "2024-10-28T21:18:55.623928Z",
+     "iopub.status.idle": "2024-10-28T21:18:56.066007Z",
+     "shell.execute_reply": "2024-10-28T21:18:56.065624Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:55.624044Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"margin: 0.1em;\n",
+       "padding-left: 0.25em;\n",
+       "border-left-style: solid;\n",
+       "font-family: var(--jp-code-font-family);\n",
+       "font-size: var(--jp-code-font-size);\n",
+       "line-height: var(--jp-code-line-height);\n",
+       "\"><span style=\"color: var(--jp-warn-color2)\">botocore.credentials</span> <span style=\"color: var(--jp-info-color0)\">INFO</span>: Found credentials in shared credentials file: /home/d/dltucker/.lsst/aws-credentials.ini</pre>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "\n",
     "# 2. Access data for this repo, collection, and day of observation\n",
@@ -529,25 +695,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "95d36237-32a9-486b-893a-646ab892ae33",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:56.066651Z",
+     "iopub.status.busy": "2024-10-28T21:18:56.066518Z",
+     "iopub.status.idle": "2024-10-28T21:18:56.084145Z",
+     "shell.execute_reply": "2024-10-28T21:18:56.083834Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:56.066638Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
     "## 2.2 Read in information from the `exposure` dimension and create pandas DataFrame\n",
     "\n",
-    "# Query the metadata for the `exposure` dimension, limiting the results to this particular instrument and day of observation:\n",
-    "query=\"instrument='%s' AND day_obs=%d\" % (instrument, day_obs)\n",
+    "# Query the metadata for the `exposure` dimension, limiting the results to this particular instrument and range of days of observation:\n",
+    "#query=\"instrument='%s' AND day_obs=%d\" % (instrument, day_obs)\n",
+    "query=\"instrument='%s' AND day_obs>=%d AND day_obs<=%d\" % (instrument, day_obs_start, day_obs_end)\n",
     "results = registry.queryDimensionRecords('exposure',where=query)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "0a3d8db3-ca82-450e-bfd9-29bbdf26cdd8",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:56.084702Z",
+     "iopub.status.busy": "2024-10-28T21:18:56.084582Z",
+     "iopub.status.idle": "2024-10-28T21:18:56.093017Z",
+     "shell.execute_reply": "2024-10-28T21:18:56.092660Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:56.084690Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are 702 results returned from querying the butler for instrument LSSTComCam between dates 20241024 and 20241028 (inclusive).\n"
+     ]
+    }
+   ],
    "source": [
     "\n",
     "# Stop executing if there are no results returned:\n",
@@ -557,14 +748,22 @@
     "if n_results <= 0:\n",
     "    raise StopExecution\n",
     "else:\n",
-    "    print(\"\"\"There are %d results returned from querying the butler for instrument %s on %d.\"\"\" % (n_results, instrument, day_obs))"
+    "    print(\"\"\"There are %d results returned from querying the butler for instrument %s between dates %d and %d (inclusive).\"\"\" % \n",
+    "          (n_results, instrument, day_obs_start, day_obs_end))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "473cdd14",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:56.093682Z",
+     "iopub.status.busy": "2024-10-28T21:18:56.093465Z",
+     "iopub.status.idle": "2024-10-28T21:18:56.097075Z",
+     "shell.execute_reply": "2024-10-28T21:18:56.096766Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:56.093671Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -581,9 +780,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "f2c9f07f",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:56.097753Z",
+     "iopub.status.busy": "2024-10-28T21:18:56.097566Z",
+     "iopub.status.idle": "2024-10-28T21:18:57.804114Z",
+     "shell.execute_reply": "2024-10-28T21:18:57.803755Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:56.097740Z"
+    },
     "tags": []
    },
    "outputs": [],
@@ -623,9 +829,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "id": "344a6240-a01b-4876-bc5a-30441b03b5f5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:57.804792Z",
+     "iopub.status.busy": "2024-10-28T21:18:57.804664Z",
+     "iopub.status.idle": "2024-10-28T21:18:57.808737Z",
+     "shell.execute_reply": "2024-10-28T21:18:57.808431Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:57.804780Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -635,9 +849,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "id": "9d71ed48-b6ff-43a9-aa91-98e5cd835e3a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:57.809278Z",
+     "iopub.status.busy": "2024-10-28T21:18:57.809159Z",
+     "iopub.status.idle": "2024-10-28T21:18:57.813717Z",
+     "shell.execute_reply": "2024-10-28T21:18:57.813443Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:57.809267Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -651,9 +873,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "id": "4121311c-592e-497a-8eca-8611374087fb",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:57.814276Z",
+     "iopub.status.busy": "2024-10-28T21:18:57.814133Z",
+     "iopub.status.idle": "2024-10-28T21:18:57.819211Z",
+     "shell.execute_reply": "2024-10-28T21:18:57.818918Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:57.814264Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -665,9 +895,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "id": "17ef1097-23b6-482a-9560-d55e38d3fa3e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:57.819724Z",
+     "iopub.status.busy": "2024-10-28T21:18:57.819609Z",
+     "iopub.status.idle": "2024-10-28T21:18:57.834422Z",
+     "shell.execute_reply": "2024-10-28T21:18:57.834129Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:57.819713Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -704,9 +942,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "id": "9e52043b-a9ee-402d-8ad8-20887e1e2f73",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:57.834953Z",
+     "iopub.status.busy": "2024-10-28T21:18:57.834826Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.131490Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.131070Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:57.834941Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -725,9 +971,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "2aeeed89-d52d-4da4-bff6-a07fa875bcf7",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.132222Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.132089Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.135098Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.134727Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.132209Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -737,9 +991,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "a90fa41a-7ac4-4236-9d77-d747052a37d3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.135721Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.135598Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.139357Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.138990Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.135709Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -755,9 +1017,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "6b93a02d-e5b4-4cc3-b7aa-2aa423c29b4e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.141977Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.141848Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.146552Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.146206Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.141965Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -774,9 +1044,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "cb6fd38f-14af-4799-8916-b91a2af3b1f3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.147233Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.147108Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.154001Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.153630Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.147221Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -793,9 +1071,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "cb209d08-c012-44c7-a6a9-537cce2f4ec9",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.154602Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.154482Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.157919Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.157551Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.154590Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -814,10 +1100,132 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "fe11f6f4-deed-41de-ba13-12fd11936fe5",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.158540Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.158419Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.168702Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.168326Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.158528Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>type</th>\n",
+       "      <th>n_exp</th>\n",
+       "      <th>i_06</th>\n",
+       "      <th>r_03</th>\n",
+       "      <th>unknown</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>acq</td>\n",
+       "      <td>77</td>\n",
+       "      <td>16</td>\n",
+       "      <td>60</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>bias</td>\n",
+       "      <td>67</td>\n",
+       "      <td>0</td>\n",
+       "      <td>67</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>cwfs</td>\n",
+       "      <td>142</td>\n",
+       "      <td>0</td>\n",
+       "      <td>136</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>dark</td>\n",
+       "      <td>67</td>\n",
+       "      <td>0</td>\n",
+       "      <td>67</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>flat</td>\n",
+       "      <td>24</td>\n",
+       "      <td>12</td>\n",
+       "      <td>12</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>focus</td>\n",
+       "      <td>242</td>\n",
+       "      <td>0</td>\n",
+       "      <td>242</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>science</td>\n",
+       "      <td>83</td>\n",
+       "      <td>4</td>\n",
+       "      <td>79</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>TOTAL</td>\n",
+       "      <td>702</td>\n",
+       "      <td>32</td>\n",
+       "      <td>663</td>\n",
+       "      <td>7</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      type  n_exp  i_06  r_03  unknown\n",
+       "0      acq     77    16    60        1\n",
+       "1     bias     67     0    67        0\n",
+       "2     cwfs    142     0   136        6\n",
+       "3     dark     67     0    67        0\n",
+       "4     flat     24    12    12        0\n",
+       "5    focus    242     0   242        0\n",
+       "6  science     83     4    79        0\n",
+       "7    TOTAL    702    32   663        7"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\n",
     "# Add a \"TOTAL\" row at the end of df_exp_merged to contain the summed totals\n",
@@ -845,9 +1253,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "acfd31b2-8e59-4902-b1a1-e190555661cb",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.169293Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.169172Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.174875Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.174507Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.169281Z"
+    }
+   },
    "outputs": [],
    "source": [
     "### 3.2.2 All Science Exposures\n",
@@ -859,9 +1275,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "7ac007d6-5b1e-4fb6-b5d3-494720c72b0c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.175496Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.175376Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.179907Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.179532Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.175484Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -875,9 +1299,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "889ddab3-3d6d-4189-8366-9be53a228ee0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.180545Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.180422Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.185192Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.184832Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.180531Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -889,9 +1321,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "75449f39-3e82-487e-b7d5-a74924dd4ddc",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.185816Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.185693Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.190473Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.190114Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.185804Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -902,9 +1342,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "aa15ef48-cca4-4727-9efc-08f3e4d500dd",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.191132Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.190976Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.201400Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.201028Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.191119Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -936,10 +1384,151 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "4558e507-a828-4836-8e06-686217138a7e",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.202086Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.201963Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.209095Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.208672Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.202075Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>science_program</th>\n",
+       "      <th>target</th>\n",
+       "      <th>tract</th>\n",
+       "      <th>n_exp</th>\n",
+       "      <th>i_06</th>\n",
+       "      <th>r_03</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>BLOCK-T208</td>\n",
+       "      <td>HD   3234</td>\n",
+       "      <td>5472</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>9</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>BLOCK-T232</td>\n",
+       "      <td>HD   3234</td>\n",
+       "      <td>5472</td>\n",
+       "      <td>18</td>\n",
+       "      <td>0</td>\n",
+       "      <td>18</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BLOCK-T60</td>\n",
+       "      <td>UNKNOWN</td>\n",
+       "      <td>5464,6130</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>BLOCK-T92</td>\n",
+       "      <td>UNKNOWN</td>\n",
+       "      <td>6131</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>BLOCK-T93</td>\n",
+       "      <td>UNKNOWN</td>\n",
+       "      <td>7766</td>\n",
+       "      <td>25</td>\n",
+       "      <td>0</td>\n",
+       "      <td>25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>unknown</td>\n",
+       "      <td>HD 212627</td>\n",
+       "      <td>7052</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>unknown</td>\n",
+       "      <td>NGC 7293</td>\n",
+       "      <td>6126</td>\n",
+       "      <td>14</td>\n",
+       "      <td>2</td>\n",
+       "      <td>12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>unknown</td>\n",
+       "      <td>UNKNOWN</td>\n",
+       "      <td>624,4760,5464,6130,620,6395</td>\n",
+       "      <td>9</td>\n",
+       "      <td>1</td>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>TOTAL</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>83</td>\n",
+       "      <td>4</td>\n",
+       "      <td>79</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  science_program     target                        tract  n_exp  i_06  r_03\n",
+       "0      BLOCK-T208  HD   3234                         5472      9     0     9\n",
+       "1      BLOCK-T232  HD   3234                         5472     18     0    18\n",
+       "2       BLOCK-T60    UNKNOWN                    5464,6130      4     0     4\n",
+       "3       BLOCK-T92    UNKNOWN                         6131      1     0     1\n",
+       "4       BLOCK-T93    UNKNOWN                         7766     25     0    25\n",
+       "5         unknown  HD 212627                         7052      3     1     2\n",
+       "6         unknown   NGC 7293                         6126     14     2    12\n",
+       "7         unknown    UNKNOWN  624,4760,5464,6130,620,6395      9     1     8\n",
+       "8           TOTAL                                             83     4    79"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "\n",
     "# Add a \"TOTAL\" row at the end of df_sci_merged to contain the summed totals\n",
@@ -985,10 +1574,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "id": "3a255c90-e086-4bf4-8796-fdfd7b08f8aa",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.209725Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.209585Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.370273Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.369858Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.209713Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA2AAAANnCAYAAABXlzscAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACatUlEQVR4nOzdd3QU1cPG8WeTbDYJoSQECL1JlSpIFRJ674gUKSKggCAKFkQFFFSaohRRQYoKIoIgvUjTH0VAioiAKL230AmbzX3/4M3KsklIKEPA7+ecHN2ZO7N35s4O++zcuWMzxhgBAAAAAO45n/tdAQAAAAD4ryCAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYClEJMmTZLNZnP/+fn5KXPmzGrZsqX++uuvBJf75JNPZLPZVKRIkbteh4CAAIWHh6tKlSp6//33deLECa9lBgwY4LHMzX/79u3zKH/+/HkNHjxYpUuXVpo0aeRwOJQrVy517NhRv/322x1vw73QoUMH5cqVy2Pae++9p9mzZ3uVXblypWw2m1auXGlJ3e6Va9eu6fnnn1fmzJnl6+urEiVKJFi2Q4cOCg4OvuU6169fryZNmihHjhxyOBzKlCmTypcvr969e3uUczqd+uyzz/T4448rNDRUQUFBypkzpxo1aqQffvhBkhQZGZnocRf3N2DAAElSdHS0Ro8erSeeeEIhISHy9/dX1qxZ1aJFC61ateq299OdSqn1SsiiRYtUr149ZciQQQ6HQ9mzZ1f79u21Y8cOr7JJPS4eZJwH/tWhQwePz16qVKmUK1cuNWzYUBMnTlR0dLTXMpGRkYqMjPSYtm/fPtWrV0+hoaGy2Wzq1auXJGnz5s2KiIhQ2rRpZbPZNHLkyLu3oXfZ2LFjNWnSpCSXv3TpkoYMGaLixYsrTZo0Sp06tfLmzXtb54F9+/bJZrMl6/1TqpvP52nTplVkZKTmz59/v6uWoiTl38KUeD7asWOHBgwY4PU98b/C735XAJ4mTpyoggUL6urVq/rf//6nwYMHa8WKFdq5c6dCQkK8yn/55ZeSpD/++EPr169X2bJl71odnE6nTpw4oV9++UVDhgzR8OHDNX36dFWvXt1rmUWLFilt2rRe0zNnzuz+/7///ls1a9bUiRMn9Pzzz2vgwIEKDg7Wvn379N1336lUqVKKioqKdz3301tvvaUXX3zRY9p7772n5s2bq3Hjxh7TH3vsMa1du1aFCxe2sIZ336effqrPPvtMo0aNUqlSpe74i/T8+fPVsGFDRUZGaujQocqcObOOHj2qjRs36ttvv9WIESPcZdu2batZs2apV69eGjhwoBwOh/755x8tWrRIixcvVpMmTTR27FidP3/eY/2DBg1yH7txsmXLplOnTql27dratm2bOnbsqFdeeUWhoaE6fPiw5syZo2rVqmnTpk0qXrz4HW1jcqXUeiXk1Vdf1bBhw1S7dm2NHTtWmTJl0u7du/Xhhx/qscce09SpU9W0adP7XU1LcR7wFBgYqOXLl0uSrly5ooMHD2rhwoXq3LmzRowYoUWLFilbtmzu8mPHjvVax0svvaT169fryy+/VHh4uPvfkI4dO+rSpUv69ttvFRIS4vWjWEoyduxYhYWFqUOHDrcs63K5VLNmTf3+++965ZVXVKZMGUnSX3/9pblz5+rnn39WREREkt87c+bMWrt2rfLmzXu71U9Rmjdvrt69eys2Nlb//POPBg0apAYNGmju3LmqV6/e/a5eirB27VqP1++++65WrFjh/izGSWnnox07dmjgwIGKjIxM0Z/ne8YgRZg4caKRZDZs2OAxfeDAgUaS+fLLL72W2bBhg5Fk6tWrZySZzp0735M6GGPM/v37Tfbs2U3q1KnNsWPH3NP79+9vJJmTJ08muu6YmBhTtGhRkyZNGvP777/HW2bBggXm0qVLd7QNVkmVKpVp3779/a7GPdOpUycTGBiYpLLt27c3qVKlSrRM5cqVTd68eY3T6fSa53K53P//zz//GEnm7bffjnc9N5a9UWLHbp06dYyfn5/56aef4l32119/Nfv370+0/vdCSq1XfKZOnWokma5du3rNu3jxoilVqpQJCgoyf//9t3t6Uo4LK8TGxprLly/fk3VzHvhXYu29ePFiY7fbTdmyZW+5nkceecTUqVPHa7qfn1+8x9/tiomJMVevXr1r67vRo48+aiIiIpJUdvny5Qn+G29Mwue8/wJJpnv37h7T9uzZYySZ6tWrJ7jctWvX4v235l64l8fR7brb59579b1sxowZRpJZsWLFPVl/SkcXxBSudOnSkqTjx497zZswYYIk6YMPPlCFChX07bff6vLly/ekHjly5NCIESN04cIFffbZZ8lefvbs2fr999/Vt2/fBLtL1qlTR0FBQQmuI65bz9dff62XX35Z4eHhCgwMVEREhDZv3uxV/scff1T58uUVFBSk1KlTq0aNGl6/FJ08eVJdunRR9uzZ5XA4lCFDBlWsWFHLli1zl7m5C6LNZtOlS5c0efJk96X9uG40CXU9Skpd4rpz/vHHH2rVqpXSpk2rTJkyqWPHjjp37pxH2RkzZqhs2bJKmzatgoKClCdPHnXs2DHBfRfn6tWr6tu3r3Lnzu3u7ta9e3dFRUV5bN/48eN15coV9/bdaXeW06dPKywsTH5+3hfdfXx8PMpJnldOEyqbFJs2bdLChQv17LPPqmrVqvGWefzxx5UjRw736+3bt6tRo0YKCQlRQECASpQoocmTJ3ssE9fOU6dO1WuvvabMmTMrODhYDRo00PHjx3XhwgV16dJFYWFhCgsL0zPPPKOLFy/edr1Onjypbt26qXDhwgoODlbGjBlVtWpV/fzzzx7LxHU/GjZsmIYMGaJcuXIpMDBQkZGR2r17t5xOp15//XVlyZJFadOmVZMmTeLtWnyzwYMHKyQkRMOHD/ealypVKo0aNUqXL1/WRx995DX/jz/+ULVq1ZQqVSplyJBBL7zwgtd5KinH8/nz59WnTx+PY7dXr166dOmSRzmbzaYXXnhB48aNU6FCheRwODR+/HhlzJhRbdu29apfVFSUAgMD9fLLL0u6/hnp3bu3SpQoobRp0yo0NFTly5fXnDlzvN6H80DS1KxZU507d9b69eu1evVq9/QbuyDG7bM9e/Zo4cKFHu9ps9kUExOjTz/91D09zrFjx/Tcc88pW7Zs8vf3V+7cuTVw4EDFxMS4y8R9LoYOHapBgwYpd+7ccjgcWrFihSRp48aNatiwoUJDQxUQEKCSJUvqu+++89iGuHqsWLFCXbt2VVhYmNKnT6+mTZvqyJEj7nK5cuXSH3/8oVWrVrnrmtiv+8k95x0+fNj9b5a/v7+yZMmi5s2bu78jJNQF8a+//lLr1q2VMWNGORwOFSpUSGPGjPEoE9cG06ZNU79+/ZQlSxalSZNG1atX165du7zqtmjRIlWrVs19/BUqVEjvv/++R5mk7NvkyJs3rzJkyKD9+/d71Pmrr75S7969lTVrVjkcDu3Zs0fS9V5CxYsXV0BAgEJDQ9WkSRP9+eefXuv94osvlD9/fjkcDhUuXFhTp071+rc/seMoqecN6d9z1MSJE1WgQAEFBgaqdOnSWrdunYwxGjZsmHLnzq3g4GBVrVrVvS13YsyYMapcubIyZsyoVKlSqWjRoho6dKicTqdHucjISBUpUkSrV69WhQoVFBQU5D6nHDp0SM2bN1fq1KmVLl06tWnTRhs2bIj3eLtVu0+aNElPPvmkJKlKlSpe55jNmzerfv367uM1S5Ysqlevng4dOnTH+yLFuN8JENcl9Av+6NGjjSQzc+ZMj+mXL182adOmNY8//rgxxpjx48cbSWbSpEl3vQ5xLl68aHx9fU21atXc0+KugB07dsw4nU6Pv5iYGHe5Ll26GEnmzz//vO36rVixwkgy2bNnN40aNTJz5841X3/9tXnkkUdMmjRpPH59/+abb4wkU7NmTTN79mwzffp0U6pUKePv729+/vlnd7latWqZDBkymM8//9ysXLnSzJ4927z99tvm22+/dZdp3769yZkzp/v12rVrTWBgoKlbt65Zu3atWbt2rfnjjz886njjLzpJrUvcvixQoIB5++23zdKlS82HH35oHA6HeeaZZ9zl1qxZY2w2m2nZsqVZsGCBWb58uZk4caJp27ZtovsvNjbW1KpVy/j5+Zm33nrLLFmyxAwfPtykSpXKlCxZ0v0r3tq1a03dunVNYGCge/tOnDiR4HqT8mtbp06djCTTo0cPs27dOnPt2rV4y128eNGkS5fOhIeHm88++8zs3bs30fXGSejYfe+994wks3DhwiStZ+fOnSZ16tQmb968ZsqUKWb+/PmmVatWRpIZMmSIu1xcO+fMmdN06NDBLFq0yIwbN84EBwebKlWqmBo1apg+ffqYJUuWmCFDhhhfX1/To0ePO6pX165dzbfffmtWrlxp5s2bZ5599lnj4+Pjcazt3bvXXa8GDRqYefPmma+//tpkypTJ5M+f37Rt29Z07NjRLFy40F3fBg0aJPreR44cMZLMU089lWi5jBkzmgIFCrhft2/f3vj7+5scOXKYwYMHmyVLlpgBAwYYPz8/U79+fXe5pBzPly5dMiVKlDBhYWHmww8/NMuWLTMff/yxSZs2ralataqJjY11l5VksmbNaooVK2amTp1qli9fbrZv325eeuklExgYaM6dO+dR77FjxxpJZtu2bcYYY6KiokyHDh3MV199ZZYvX24WLVpk+vTpY3x8fMzkyZPdy3Ee8HSr88CiRYuMJPPuu++6p0VERLivFJ07d86sXbvWhIeHm4oVK7rf89ixY2bt2rVGkmnevLl7ujHGHD161GTPnt3kzJnTfPbZZ2bZsmXm3XffNQ6Hw3To0MH9PnGfi6xZs5oqVaqY77//3ixZssTs3bvXLF++3Pj7+5tKlSqZ6dOnm0WLFpkOHToYSWbixInudcSdY/LkyWN69OhhFi9ebMaPH29CQkJMlSpV3OV+++03kydPHlOyZEl3XX/77bcE98vevXuN3W43+fPnN19//bU5cuRIgmUPHTpkMmfO7PE5mD59uunYsaP739a4bb2x7n/88YdJmzatKVq0qJkyZYpZsmSJ6d27t/Hx8TEDBgxwl4s7bnPlymXatGlj5s+fb6ZNm2Zy5Mhh8uXL5/Fv+vjx443NZjORkZFm6tSpZtmyZWbs2LGmW7du7jJJ3bcJUTxXwM6cOWN8fHxMhQoVPOqcNWtW07x5c/Pjjz+aefPmmdOnT7vPs61atTLz5883U6ZMMXny5DFp06Y1u3fvdq/zs88+M5JMs2bNzLx588w333xj8ufPb3LmzOnxb39ix1FSzxtx25UzZ05ToUIFM2vWLPPDDz+Y/Pnzm9DQUPPSSy+ZRo0aueuRKVMmU6xYMY9z3K3E91l86aWXzKeffmoWLVpkli9fbj766CMTFhbmcU4x5vpnMjQ01GTPnt2MGjXKrFixwqxatcpcvHjRPPLIIyY0NNSMGTPGLF682Lz00ksmd+7cXu2ZlHY/ceKEu33GjBnjcY65ePGiSZ8+vSldurT57rvvzKpVq8z06dPN888/b3bs2JHk/ZDSEcBSiLiT+7p164zT6TQXLlwwixYtMuHh4aZy5cpel9OnTJliJJlx48YZY4y5cOGCCQ4ONpUqVbrjOiQUwIwxJlOmTKZQoULu13FfFuL7y5s3r7tc7dq1jaQ7ulQfd6J97LHHPE5G+/btM3a73XTq1MkYc73LRpYsWUzRokU9um9cuHDBZMyY0X3iNsaY4OBg06tXr0Tf9+YAZkzCXY9u/uKVnLrE7cuhQ4d6rLNbt24mICDAvc3Dhw83kkxUVFSi9b5Z3Begm9c/ffp0I8l8/vnnHtuc1C4MSSl76tQp88QTT7iPDbvdbipUqGDef/99c+HCBY+y8+fPN2FhYe6y6dOnN08++aT58ccfE1x/Qsfu888/bySZnTt3JmlbWrZsaRwOhzlw4IDH9Dp16pigoCD3Po9r55vDS69evYwk07NnT4/pjRs3NqGhobddr5vFxMQYp9NpqlWrZpo0aeKeHvcFoXjx4h7H28iRI40k07Bhw3jre3MoudG6deuMJPP6668nWqeyZct6dFdr3769kWQ+/vhjj3KDBw82kswvv/xijEna8fz+++8bHx8fr/b9/vvvjSSzYMEC9zRJJm3atObMmTMeZbdt2+Z1nBtjTJkyZUypUqUSfO+4ff3ss8+akiVLeszjPPCvW5X9888/vbqx3hjA4uTMmdPUq1fPa/n4vow/99xzJjg42Kurbty+iQvEcZ+LvHnzev34U7BgQVOyZEmvf2Pr169vMmfO7G6vuHPMjQHDGGOGDh1qJJmjR4+6pyWnC6IxxkyYMMEEBwe7z3mZM2c27dq1M6tXr/Yo17FjR2O32xP9EhpfAKtVq5bJli2b1+f8hRdeMAEBAe7PStxxW7duXY9y3333nZHkDr4XLlwwadKkMU888USiwSCp+zYhcfvb6XSaa9eumT///NPUqVPH/aX9xjpXrlzZY9mzZ8+6fyC50YEDB4zD4TCtW7c2xlz/bIaHh3t1j92/f7+x2+3xBrD4jqObJXbekGTCw8PNxYsX3dNmz55tJJkSJUp47NO4c3fcD0RJcavPosvlMk6n00yZMsX4+vp6nCsjIiKMJK+u8WPGjIn3R8PnnnvO63hLarsn1AVx48aNRpKZPXt2krf5QUQXxBSmXLlystvtSp06tWrXrq2QkBDNmTPHq+vWhAkTFBgYqJYtW0qSgoOD9eSTT+rnn39OdNTEO2WMiXf6smXLtGHDBo+/+EYHuxtat27t0QUlZ86cqlChgrs7ya5du3TkyBG1bdvWo/tGcHCwmjVrpnXr1rm7QJUpU0aTJk3SoEGDtG7dOq/L8XcqOXWJ07BhQ4/XxYoV09WrV91dxR5//HFJUosWLfTdd9/p8OHDSapL3A25N98Y/uSTTypVqlT66aefkrVtyZE+fXr9/PPP2rBhgz744AM1atRIu3fvVt++fVW0aFGdOnXKXbZu3bo6cOCAfvjhB/Xp00ePPvqoZs+erYYNG+qFF164Z3WUru+jatWqKXv27B7TO3TooMuXL3t1F6tfv77H60KFCkmS183hhQoV0pkzZzy6ISbXuHHj9NhjjykgIEB+fn6y2+366aef4u1OU7duXY/jLbF6SdKBAwduu15xjDEen8s4bdq08XjdunVrSXJ/XpNyPM+bN09FihRRiRIlFBMT4/6rVatWvF39qlat6jVoUdGiRVWqVClNnDjRPe3PP//Ur7/+6tVtb8aMGapYsaKCg4Pd+3rChAnx7uuk4DyQ8L8dd2LevHmqUqWKsmTJ4nFc1KlTR5K8RhBs2LCh7Ha7+/WePXu0c+dO9zF64zrq1q2ro0ePenW9i69dJLm7xN2Ojh076tChQ5o6dap69uyp7Nmz6+uvv1ZERISGDRvmLrdw4UJVqVLF/blNiqtXr+qnn35SkyZNFBQU5LWNV69e1bp165K1jWvWrNH58+fVrVu3eD/z0u3t2/iMHTtWdrtd/v7+KlSokNasWaN33nlH3bp18yjXrFkzj9dr167VlStXvI7z7Nmzq2rVqu7jfNeuXTp27JhatGjhUS5HjhyqWLFivHW6+TiKk5zzRpUqVZQqVSr367g2rVOnjsc+jZt+J8eXdL1LX8OGDZU+fXr5+vrKbrerXbt2crlc2r17t0fZkJAQr67xq1atcn8vvVGrVq08Xt+Ndn/kkUcUEhKi1157TePGjYt3lN2HAQEshZkyZYo2bNig5cuX67nnntOff/4Z7wG+evVq1atXT8YYRUVFKSoqSs2bN5f078iId9ulS5d0+vRpZcmSxWte8eLFVbp0aY+/G+/1iruXZe/evXdcj/Dw8HinxfWlT6xPfZYsWRQbG6uzZ89KkqZPn6727dtr/PjxKl++vEJDQ9WuXTsdO3bsjuuZ3LrESZ8+vcdrh8Mh6fqoYpJUuXJlzZ49WzExMWrXrp2yZcumIkWKaNq0abesi5+fnzJkyOAx3Wazeey/e6l06dJ67bXXNGPGDB05ckQvvfSS9u3bp6FDh3qUCwwMVOPGjTVs2DCtWrVKe/bsUeHChTVmzBj98ccfSX6/5B53p0+fTrCt4ubfKDQ01OO1v79/otOvXr16W/X68MMP1bVrV5UtW1YzZ87UunXrtGHDBtWuXdt9XNyNesUnqXXdv3+/V3D18/PzOp7jPr9x+zIpx/Px48e1bds22e12j7/UqVPLGOMR4KWE76fp2LGj1q5dq507d0q6PuKrw+HwOMfOmjVLLVq0UNasWfX1119r7dq12rBhgzp27JjofkoM54F/v0DG9+/H7Tp+/Ljmzp3rdVw8+uijknTL4yLuvqk+ffp4rSPuC/7N67hVu9yutGnTqlWrVvr444+1fv16bdu2TZkyZVK/fv3c9+adPHnSYxTJpDh9+rRiYmI0atQor22sW7eupORv48mTJyUp0brczr6NT4sWLbRhwwZt3LhRu3bt0unTp/XWW295lbu5bW/1mbv5+0KmTJm8ysU3LaF1Jve8cTfP0bdy4MABVapUSYcPH9bHH3/s/jE07h7Am4/d+Lbv9OnTSdpHd6Pd06ZNq1WrVqlEiRJ644039OijjypLlizq37//Xf+R/H5iGPoUplChQu6BN6pUqSKXy6Xx48fr+++/9whYxhh9//33+v77773WMXnyZA0aNEi+vr53tW7z58+Xy+Xyem5LUtSqVUuff/65Zs+erddff/2O6hFfODp27Jj7H424/x49etSr3JEjR+Tj4+P+dTwsLEwjR47UyJEjdeDAAf344496/fXXdeLECS1atOiO6pncuiRHo0aN1KhRI0VHR2vdunV6//331bp1a+XKlUvly5dPsC4xMTE6efKkx5cvY4yOHTvm/kXdKna7Xf3799dHH32k7du3J1o2R44c6tKli3r16qU//vjD/QXrVmrVqqU33nhDs2fP9vrlLj7p06dPsK2k68fL3ZDcen399deKjIzUp59+6jH9woULd6U+icmcObMeffRRLVmyRJcvX453oJy1a9fq+PHj7puq48TExOj06dMeX+jiPr83TrvV8RwWFqbAwMAEf1y6uV0S+lW+VatWevnllzVp0iQNHjxYX331lRo3buzxGfz666+VO3duTZ8+3WM98T3HKqk4D1wfgETSbf37kZCwsDAVK1ZMgwcPjnf+zWHv5uMi7rjp27dvgo9QKFCgwF2oafI9+uijatmypUaOHKndu3erTJkyypAhQ7IHIQgJCZGvr6/atm2r7t27x1smd+7cyVpn3HGTWF3u1r7NkCGD+ztRYm5u21t95uLqF1cuvoHOEvohNr7zy704b9wts2fP1qVLlzRr1izlzJnTPX3Lli3xlo9v+9KnT69ff/3Va/rN++hutXvRokX17bffyhijbdu2adKkSXrnnXcUGBh4x98hUwqugKVwQ4cOVUhIiN5++23FxsbK5XJp8uTJyps3r1asWOH117t3bx09elQLFy68q/U4cOCA+vTpo7Rp0+q5555L9vKNGjVS0aJF9f777yf4ZXvx4sVJGsVx2rRpHt1Z9u/frzVr1rj/YS9QoICyZs2qqVOnepS7dOmSZs6c6R6F7GY5cuTQCy+8oBo1atzyodAOhyNJv3jebl2SyuFwKCIiQkOGDJGkeEeDjFOtWjVJ1/+huNHMmTN16dIl9/x7Ib5/BCW5u2bEfVG6cOFCgt30bi6bFI899pjq1KmjCRMmeD0TJc7GjRvdXfCqVaum5cuXe4xqJl2/Mh0UFKRy5col+b3vZr1sNpv7V+g427Zt8+oSea/069dPZ8+eVZ8+fbzmXbp0ST179lRQUJBeeuklr/nffPONx+upU6dKiv+LeELHc/369fX3338rffr0XlfaS5cuneRnyISEhKhx48aaMmWK5s2bp2PHjnl1P7TZbPL39/caaS++0cw4DyTN0qVLNX78eFWoUEFPPPHEXVtv/fr1tX37duXNmzfe4+JW54oCBQooX7582rp1a7zLly5dWqlTp052vZJ6XEjXryxcu3Yt3nlxV2rjtqNOnTpasWJFkrruxQkKClKVKlW0efNmFStWLN5tvPmK161UqFBBadOm1bhx4xLsWnqv9m1SlS9fXoGBgV7H+aFDh9xdzePqGR4e7jUy44EDB7RmzZokv19yzhtWi6vTjf+GGGP0xRdfJHkdERERunDhgtd3y2+//dbjdXLaPSlXj202m4oXL66PPvpI6dKlu+V3swcJV8BSuJCQEPXt21evvvqqpk6dqnTp0unIkSMaMmRIvF9gihQpotGjR2vChAnu+1M6dOigyZMna+/evUn6orJ9+3Z3n90TJ07o559/1sSJE+Xr66sffvjBq+uKdH1Y7fgeoFy4cGGlSZPGvWzNmjVVvnx5de3a1d0Hev/+/fr+++81d+5cr2448Tlx4oSaNGmizp0769y5c+rfv78CAgLUt29fSdeH7R06dKjatGmj+vXr67nnnlN0dLSGDRumqKgoffDBB5Kkc+fOqUqVKmrdurUKFiyo1KlTa8OGDVq0aNEtHyhbtGhRrVy5UnPnzlXmzJmVOnXqeH/VSWpdkuPtt9/WoUOHVK1aNWXLlk1RUVH6+OOPZbfbE31gZ40aNVSrVi299tprOn/+vCpWrKht27apf//+KlmyZLxDdCeVy+WK92psqlSpVKdOHdWqVUvZsmVTgwYNVLBgQcXGxmrLli0aMWKEgoOD3Q+63rVrl2rVqqWWLVsqIiJCmTNn1tmzZzV//nx9/vnnioyMVIUKFZJVtylTpqh27dqqU6eOOnbsqDp16igkJERHjx7V3LlzNW3aNG3atEk5cuRQ//793feVvP322woNDdU333yj+fPna+jQoXf1IeHJqVf9+vX17rvvqn///oqIiNCuXbv0zjvvKHfu3B7Dbd8rrVq10m+//abhw4dr37596tixozJlyqRdu3bpo48+0t9//62pU6cqT548Hsv5+/trxIgRunjxoh5//HGtWbNGgwYNUp06ddxfxJNyPPfq1UszZ85U5cqV9dJLL6lYsWKKjY3VgQMHtGTJEvXu3TvJD6Hv2LGjpk+frhdeeEHZsmXzerB8/fr1NWvWLHXr1k3NmzfXwYMH9e677ypz5sxe99dyHvAUGxvrvp8oOjpaBw4c0MKFC/Xdd9+pUKFCdzT8eHzeeecdLV26VBUqVFDPnj1VoEABXb16Vfv27dOCBQs0bty4W3bZ++yzz9znqA4dOihr1qw6c+aM/vzzT/3222+aMWNGsusV9+v99OnTlSdPHgUEBKho0aLxll2xYoVefPFFtWnTRhUqVFD69Ol14sQJTZs2TYsWLXJ3L43b3oULF6py5cp64403VLRoUUVFRWnRokV6+eWXPR5Cf6OPP/5YTzzxhCpVqqSuXbsqV65cunDhgvbs2aO5c+cm+CNQQoKDgzVixAh16tRJ1atXV+fOnZUpUybt2bNHW7du1ejRoyXdm32bVOnSpdNbb72lN954Q+3atVOrVq10+vRpDRw4UAEBAerfv7+k65/NgQMH6rnnnlPz5s3VsWNHRUVFaeDAgcqcOXOSH32SnPOG1WrUqCF/f3+1atVKr776qq5evapPP/00Sd+34rRv314fffSRnn76aQ0aNEiPPPKIFi5cqMWLF0vyfFxCUts97jaVzz//XKlTp1ZAQIBy586ttWvXauzYsWrcuLHy5MkjY4xmzZqlqKgo1ahR4y7umfvM+nE/EJ/ERiC8cuWKexjYxo0bG39//0SHA27ZsqXx8/NzPzC5WbNmJjAw0Jw9ezZJdYj78/f3NxkzZjQRERHmvffei/c9ExsFUZJZunSpR/moqCjz7rvvmscee8wEBwcbu91ucuTIYZ5++mnzv//9L9H6xY129NVXX5mePXuaDBkyGIfDYSpVqmQ2btzoVX727NmmbNmyJiAgwKRKlcpUq1bN4z2uXr1qnn/+eVOsWDGTJk0aExgYaAoUKGD69+/v8eDB+EZB3LJli6lYsaIJCgoyktwjXsU3/HRS6nLjvrz5odZx7RI3JPu8efNMnTp1TNasWd1tVLduXY+hrBNy5coV89prr5mcOXMau91uMmfObLp27ep1bCR39LOE2j9uv02fPt20bt3a5MuXz6Pd27Zt6zGi19mzZ82gQYNM1apV3duXKlUqU6JECTNo0KAEH6h7qxE8r1y5Yj755BNTvnx5kyZNGuPn52eyZMlimjZtaubPn+9R9vfffzcNGjQwadOmNf7+/qZ48eJeQybHtfOMGTOSVI+E2jap9YqOjjZ9+vQxWbNmNQEBAeaxxx4zs2fP9jo240bpGjZs2B3VNyELFiwwdevWNenTpzd2u91kzZrVtG3b1j3a3I3ijqFt27aZyMhIExgYaEJDQ03Xrl09Rv9K6vF88eJF8+abb5oCBQoYf39/97DaL730ksfD4RXPaHk3crlcJnv27EaS6devX7xlPvjgA5MrVy7jcDhMoUKFzBdffOFuwxtxHvAse+NnPzAw0OTIkcM0aNDAfPnllyY6OtprmTsdBdEYY06ePGl69uxpcufObex2uwkNDTWlSpUy/fr1cx9nCX0u4mzdutW0aNHCZMyY0djtdhMeHm6qVq3qHmXYmIQ/K/G19b59+0zNmjVN6tSpPc6D8Tl48KB58803TcWKFU14eLjx8/MzqVOnNmXLljWjRo3yGPo9rnzHjh1NeHi4sdvtJkuWLKZFixbm+PHjHtt68zlr7969pmPHjiZr1qzGbrebDBkymAoVKphBgwZ5bcvN54mE1rlgwQITERFhUqVKZYKCgkzhwoU9HteR1H2bkFt9lhOrc5zx48ebYsWKuc8ZjRo1ivd89fnnn5tHHnnE+Pv7m/z585svv/zSNGrUyGMEw1sdR0k9b8S3Xck9dycmvs/t3LlzTfHixU1AQIDJmjWreeWVV8zChQu9jt2IiAjz6KOPxrveAwcOmKZNm5rg4GCTOnVq06xZM7NgwQIjycyZM8ejbFLbfeTIkSZ37tzG19fXfYzt3LnTtGrVyuTNm9cEBgaatGnTmjJlytzRY5ZSIpsx92BoIqQo4eHhatu2rcdoSg+ilStXqkqVKpoxY4b7fjgAAIC7KSoqSvnz51fjxo31+eef3+/qpFjvvfee3nzzTR04cCDZA8T819EF8SH3xx9/6PLly3rttdfud1UAAABSlGPHjmnw4MGqUqWK0qdPr/379+ujjz7ShQsX3N3jIXfX0oIFC8rpdGr58uX65JNP9PTTTxO+bgMB7CH36KOP6vz58/e7GgAAACmOw+HQvn371K1bN505c8Y94NK4ceOSPOLuf0FQUJA++ugj7du3T9HR0cqRI4dee+01vfnmm/e7ag8kuiACAAAAgEUYhh4AAAAALEIAAwAAAACLEMAAJMvKlStls9nife7X7dqxY4cGDBigffv23bV1piQul0sffvihateurWzZsikoKEiFChXS66+/rqioqHiXGTVqlAoWLCiHw6HcuXNr4MCBcjqdHmVmzZqlVq1a6ZFHHlFgYKBy5cqlNm3a3PK5M1euXFH+/Plls9k0fPhwr/lvvvmm6tevr6xZs8pms6lDhw4Jruuff/5R06ZNlS5dOgUHB8f7IPOjR4/qzTffVPny5RUWFqY0adKoVKlS+vzzz+VyuRKt6/jx42Wz2RQcHJxoufshV65cie4bKfnbfvHiRfXq1UtZsmRRQECASpQo4fWw09s5nuLs2LFDDodDNptNGzdu9Jh36NAh9erVSxEREUqXLp1sNpsmTZqU4LqWLVvmfoh0WFiYOnTooBMnTniU2bRpk7p3766iRYsqderUypQpk6pXr57gs6dmzpypihUrKjQ0VOnSpVOZMmX01VdfJbpNN3I6nSpYsKDHs9UmTZokm812T88vNptNAwYMeGDXv3v3bvn7+z9UD7oFUjICGID7bseOHRo4cOBDG8CuXLmiAQMGKGfOnBo5cqQWLFigzp076/PPP1fFihV15coVj/KDBw/Wiy++qKZNm2rx4sXq1q2b3nvvPXXv3t2j3JAhQ3T58mX169dPixYt0qBBg7R582Y99thj+uOPPxKsz1tvvaVLly4lOP+jjz7S6dOn1bBhQ/n7+ydY7uTJk6pUqZJ2796tL7/8Ut99952uXr2qyMhI7dq1y11u06ZNmjJliqpVq6YpU6Zo5syZioiIUNeuXdW5c+cE13/48GH16dNHWbJkSbBMSpfcbW/atKkmT56s/v37a+HChXr88cfVqlUrTZ061V0mucdTHJfLpY4dOyosLCze+Xv27NE333wjf39/1a1bN9HtWrVqlerUqaNMmTJpzpw5+vjjj7Vs2TJVq1ZN0dHR7nLTpk3Tr7/+qo4dO2rOnDkaP368HA6He3/c6Msvv1Tz5s2VOXNmffPNN/r222+VN29etWvXTh999FGi9YkzduxYnT17Vj169HBPq1evntauXavMmTMnaR0p0dq1a9WpU6d7tv78+fOrTZs2eumll+7ZewC4wf19DBmAB83tPBjyVmbMmBHvg2sfFjExMebUqVNe0+O2+6uvvnJPO3XqlAkICDBdunTxKDt48GBjs9k8HiIa9/DVGx0+fNjY7Xbz7LPPxluX9evXG39/f/d7x/dQUZfL5f7/VKlSmfbt28e7rldeecXY7Xazb98+97Rz586ZsLAw06JFC/e0M2fOmGvXrnkt3717dyPJHDhwIN71169f3zRo0CBZDwS2Us6cORPcN3GSs+3z5883kszUqVM9ytaoUcNkyZLF/VDe5BxPNxo2bJjJmjWr+fjjj+N9qPCN7b5hw4Z4H74b5/HHHzeFCxc2TqfTPe1///ufkWTGjh3rnhbfMRoTE2OKFStm8ubN6zG9YsWKJmfOnB71iI2NNQULFjTFihWLtx43cjqdJmvWrOb111+/Zdm7TZLp37+/5e97N23cuNFI8no4OIC7jytgAG7L1atX9fLLLys8PFyBgYGKiIjQ5s2bvcpt3LhRDRs2VGhoqAICAlSyZEl999137vmTJk3Sk08+KUmqUqWKbDabu+vTmDFj5OPj49GtacSIEbLZbB5Xg2JjYxUSEqLevXu7p127dk2DBg1yd+PLkCGDnnnmGZ08edKrjtOnT1f58uWVKlUqBQcHq1atWl7b0qFDBwUHB2vPnj2qW7eugoODlT17dvXu3dvjF//4+Pr6Kn369F7Ty5QpI0k6ePCge9qiRYt09epVPfPMMx5ln3nmGRljNHv2bPe0jBkzeq0zS5YsypYtm8c6b9wnHTt2VPfu3VW6dOkE6+vjk7R/Gn744QdVrVpVOXPmdE9LkyaNmjZtqrlz5yomJkaSFBISIrvd7rV83PYfOnTIa97XX3+tVatWaezYsUmqS5yNGzeqZcuWypUrl7tbZqtWrbR//36PcnHd0lasWKGuXbsqLCxM6dOnV9OmTXXkyBGPsk6nU6+++qrCw8MVFBSkJ554Qr/++muS6pOcbf/hhx8UHBzs/jzEeeaZZ3TkyBGtX79eUvKOpzh//fWX3n77bY0dO1Zp0qSJt65JbffDhw9rw4YNatu2rfz8/n2aTYUKFZQ/f3798MMP7mnxHaO+vr4qVaqUVz3tdruCg4M96mGz2ZQmTRoFBATcsl4//vijDh8+rLZt23pMj68LYmRkpIoUKaINGzaoUqVKCgoKUp48efTBBx8oNjbWY/moqCj17t1befLkkcPhUMaMGVW3bl3t3LkzwboMGDBANpvNa3p8dVm+fLkiIyOVPn16BQYGKkeOHGrWrJkuX77ssR/iuiBu3bpVNptNEyZM8Fr/woULZbPZ9OOPP7qn/fXXX2rdurUyZswoh8OhQoUKacyYMV7LlipVSoUKFdK4ceMS3C4AdwcBDMBteeONN/TPP/9o/PjxGj9+vI4cOaLIyEj9888/7jIrVqxQxYoVFRUVpXHjxmnOnDkqUaKEnnrqKfe9JfXq1dN7770nSRozZozWrl2rtWvXql69eqpevbqMMfrpp5/c61y2bJkCAwO1dOlS97SNGzcqKipK1atXl3Q9kDVq1EgffPCBWrdurfnz5+uDDz7Q0qVLFRkZ6dFF67333lOrVq1UuHBhfffdd/rqq6904cIFVapUSTt27PDYZqfTqYYNG6patWqaM2eOOnbsqI8++khDhgy5rX0Ydx/Mjc+a2b59uySpaNGiHmUzZ86ssLAw9/yE/PPPP9q/f3+8z6955513dOnSJb377ru3Vd8bXblyRX///beKFSvmNa9YsWK6cuWKx7EQn+XLl8vPz0/58+f3mH7ixAn16tVLH3zwQbIf8Llv3z4VKFBAI0eO1OLFizVkyBAdPXpUjz/+uE6dOuVVvlOnTrLb7Zo6daqGDh2qlStX6umnn/Yo07lzZw0fPlzt2rXTnDlz1KxZMzVt2lRnz55NVt1uFN+2b9++XYUKFfIINZLc+/hWbR/f8SRJxhh16tRJ9evXV8OGDW+7zjfW88Z63VzXW9UzJiZGP//8s1c9e/TooT///FODBw/WyZMnderUKQ0fPlybNm1Snz59blmv+fPnK2PGjCpcuHCStuPYsWNq06aNnn76af3444+qU6eO+vbtq6+//tpd5sKFC3riiSf02Wef6ZlnntHcuXM1btw45c+fX0ePHk3S+yRm3759qlevnvz9/fXll19q0aJF+uCDD5QqVSpdu3Yt3mWKFy+ukiVLauLEiV7zJk2a5A6I0vXu3Y8//ri2b9+uESNGaN68eapXr5569uypgQMHei0fGRmphQsXyvCEIuDeur8X4AA8aOK6ID722GMmNjbWPX3fvn3GbrebTp06uacVLFjQlCxZ0qObkjHXu5ZlzpzZ3dUosS6I2bJlMx07djTGGBMdHW1SpUplXnvtNSPJ7N+/3xhzvXue3W43Fy9eNMYYM23aNCPJzJw502Ndcd2q4rpIHThwwPj5+ZkePXp4lLtw4YIJDw/36EbXvn17I8l89913HmXr1q1rChQocOsdd5NDhw6ZTJkymdKlS3t0uercubNxOBzxLpM/f35Ts2bNBNfpdDpNZGSkSZMmjVe3vs2bNxu73W4WLVpkjDFm7969CXZBvFFCXRAPHz5sJJn333/fa97UqVONJLNmzZoE17t48WLj4+NjXnrpJa95zZo1MxUqVHAfX3fSBTEmJsZcvHjRpEqVynz88cfu6RMnTjSSTLdu3TzKDx061EgyR48eNcYY8+effxpJXvX85ptvjKRbdkGMT0Lbni9fPlOrVi2v8keOHDGSzHvvvZfgOhM6nowxZtSoUSYkJMQcO3bMGPPvtt/cBfFGiXVBjNv2tWvXes3r0qWL8ff3T3C9xhjTr18/I8nMnj3ba97s2bNN2rRpjSQjyQQGBpqvv/460fXFKVSokKldu7bX9Ljt3bt3r3taRESEkWTWr1/vUbZw4cIebfDOO+8YSWbp0qWJvrdu6oLYv39/E99XrJvr8v333xtJZsuWLcla/yeffGIkmV27drmnnTlzxjgcDtO7d2/3tFq1apls2bKZc+fOeazvhRdeMAEBAebMmTMe07/44gsjyfz555+J1gfAneEKGIDb0rp1a48uNjlz5lSFChW0YsUKSddv6N+5c6fatGkj6fqv3nF/devW1dGjRz0GakhItWrVtGzZMknSmjVrdPnyZb388ssKCwtzXwWLG40tVapUkqR58+YpXbp0atCggcf7lihRQuHh4Vq5cqUkafHixYqJiVG7du08ygUEBCgiIsJdLo7NZlODBg08phUrVsyre9utnDlzRnXr1pUxRtOnT/fq+hVf16VbzTPG6Nlnn9XPP/+sKVOmKHv27O55MTEx6tixo5566inVqlUrWXW9ldup62+//aYWLVqoXLlyev/99z3mzZw5U3PnztUXX3yR6LoTcvHiRb322mt65JFH5OfnJz8/PwUHB+vSpUv6888/vcrffEUo7qpOXJvGHc9xx3GcFi1aeF2pSorEtl26vf2Z2PG0f/9+9e3bV8OGDVOmTJmSXd/EJFSfxLZh/PjxGjx4sHr37q1GjRp5zFu0aJGefvppNW3aVAsXLtTSpUvVqVMndejQId6rPTc7cuRIvF0eExIeHu7uthnn5s/zwoULlT9/fvfV9butRIkS8vf3V5cuXTR58uRbXjWO06ZNGzkcDo9RKqdNm6bo6Gh39+WrV6/qp59+UpMmTRQUFOR1Dr569arWrVvnsd64/Xf48OG7s4EA4kUAA3BbwsPD4512+vRpSdLx48clSX369JHdbvf469atmyTF2yXsZtWrV9eBAwf0119/admyZSpZsqQyZsyoqlWratmyZbpy5YrWrFnj8QXp+PHjioqKkr+/v9d7Hzt2zP2+cXV8/PHHvcpNnz7dq35BQUFe96I4HA5dvXo1qbtNZ8+eVY0aNXT48GEtXbpUefLk8ZifPn16Xb161eP+jzhnzpxRaGio13Tz/13Mvv76a02aNMnri+3IkSP1zz//qH///oqKilJUVJTOnz8v6fqXtKioqFsOB3+zkJAQ2Ww2d3vfXE9J8dZ18+bNqlGjhvLly6cFCxbI4XC45128eFHdu3dXjx49lCVLFndd47piRUVFJTp6o3T9h4HRo0erU6dOWrx4sX799Vdt2LBBGTJkiHd0wJvvpYqrT1zZuO27+Xj38/OL9z6sxCS27XF1Se7+vNXx1L17dxUpUkTNmjVz78+4Y+vixYs6d+5csrYhrp6SEqxrfPWUpIkTJ+q5555Tly5dNGzYMI95xhh17NhRlStX1pdffqnatWurevXq+uSTT9S6dWv16NHjlm1/5cqVJN0rdvN23MjhcHgcJydPnkx2N9jkyJs3r5YtW6aMGTOqe/fuyps3r/LmzauPP/440eVCQ0PVsGFDTZkyxf3ZnTRpksqUKePu2nn69GnFxMRo1KhRXue3uC6KN5/j4vZfQiNpArg7kv/zHQDo+v0T8U2L+1ITN9R137591bRp03jXUaBAgVu+T7Vq1SRdv8q1dOlS1ahRwz39zTff1OrVqxUdHe0RwOIGVFi0aFG860ydOrVHHb///nuPgSTulbNnz6p69erau3evfvrpp3jvoYm79+v3339X2bJl3dPjgmORIkU8yseFr4kTJ2rChAle9y9J1+/ZOXfunPLly+c176233tJbb72lzZs3q0SJEknelsDAQD3yyCP6/fffveb9/vvvCgwM9AoDmzdvVvXq1ZUzZ04tWbJEadOm9Zh/6tQpHT9+XCNGjNCIESO81hsSEqJGjRp5DERyo3PnzmnevHnq37+/Xn/9dff06Ohod4hJrrjj+dixY8qaNat7ekxMTLwBJCG32nbpettPmzZNMTExHlfX4vbxzW2flONp+/bt2r9/v0JCQrzmValSRWnTpr3ls8NuFleP33//3Wu4+t9//92rntL18NWpUye1b99e48aN87pKdvz4cR09elTPPfec17KPP/64pkyZon379sV7b2OcsLCw227nhGTIkCHeQWJuJS7IREdHewTt+H50qlSpkipVqiSXy6WNGzdq1KhR6tWrlzJlyqSWLVsm+B7PPPOMZsyYoaVLlypHjhzasGGDPv30U/f8kJAQ+fr6qm3btl6PsIiTO3duj9dx+y+hRxUAuDsIYABuy7Rp0/Tyyy+7v0jt379fa9asUbt27SRdD1f58uXT1q1b3YNsJOTmqw43ypw5swoXLqyZM2dq06ZN7nXVqFFDzz33nD788EOlSZNGjz/+uHuZ+vXr69tvv5XL5fIIMTerVauW/Pz89Pfff6tZs2bJ2wHJFPdl+Z9//tHSpUtVsmTJeMvVrl1bAQEBmjRpkkfd40ZPa9y4sXuaMUadO3fWxIkT3YMExOf111/3emDwsWPH1KpVKz3//PN66qmn9MgjjyR7m5o0aaKRI0fq4MGD7i6PFy5c0KxZs9SwYUOPELFlyxZVr15d2bJl09KlS+MNBOHh4e4ufzf64IMPtGrVKi1cuDDRL4Y2m03GGK8rS+PHj0/2Fb44kZGRkqRvvvlGpUqVck//7rvv3KM83kpStl26vj+/+OILzZw5U0899ZR7+uTJk5UlSxaP4yGpx9O3337rdYV20aJFGjJkiMaNG5dooElI1qxZVaZMGX399dfq06ePfH19JUnr1q3Trl271KtXL4/ykyZNUqdOnfT000+7H6x9s5CQEAUEBHh1iZOuPwPLx8fnls/xKliwoP7+++9kb09i6tSpo7ffflvLly9X1apVk7xcrly5JEnbtm3zODfNnTs3wWV8fX1VtmxZFSxYUN98841+++23RANYzZo1lTVrVk2cOFE5cuRQQECAWrVq5Z4fFBSkKlWqaPPmzSpWrFiiz/SL888//8jHxydJP44BuH0EMAC35cSJE2rSpIk6d+6sc+fOqX///goICFDfvn3dZT777DPVqVNHtWrVUocOHZQ1a1adOXNGf/75p3777TfNmDFD0r+/qH/++edKnTq1AgIClDt3bvfVh2rVqmnUqFEKDAxUxYoVJV3/5TZ37txasmSJ15f9li1b6ptvvlHdunX14osvqkyZMrLb7Tp06JBWrFihRo0aqUmTJsqVK5feeecd9evXT//8849q166tkJAQHT9+XL/++qtSpUoV70hhyXXlyhX30PYjR45UTEyMxxfNDBkyKG/evJKudy1688039dZbbyk0NFQ1a9bUhg0bNGDAAHXq1MljhLeePXtqwoQJ6tixo4oWLeqxTofD4f5SXrBgQRUsWNCjTnHDYOfNm9cdMuKsWrXKPVy/y+XS/v379f3330uSIiIilCFDBknXu5d+9dVXqlevnt555x05HA598MEHunr1qnvIbEnatWuX+wrl4MGD9ddff+mvv/5yz8+bN68yZMiggIAAr7pI17/A+/r6xjvvRmnSpFHlypU1bNgwhYWFKVeuXFq1apUmTJigdOnSJbpsQgoVKqSnn35aI0eOlN1uV/Xq1bV9+3YNHz48weHcb5TUbZeuf9mvUaOGunbtqvPnz+uRRx7RtGnTtGjRIn399dfuoJOc46lcuXJedYpr+1KlSnk9jiCunePuRdq4caOCg4MlSc2bN3eXGzJkiGrUqKEnn3xS3bp104kTJ/T666+rSJEiHj8EzJgxQ88++6xKlCih5557zmv4/pIlS8rhcMjhcKhbt2768MMP1a5dOz311FPy9fXV7NmzNXXqVD377LMJdm2MExkZqXfeeUeXL19WUFBQomWTqlevXpo+fboaNWqk119/XWXKlNGVK1e0atUq1a9fX1WqVIl3ubp16yo0NFTPPvus3nnnHfn5+WnSpEleQ++PGzdOy5cvV7169ZQjRw5dvXpVX375pSTd8r4zX19ftWvXzv0jVNOmTb2urH788cd64oknVKlSJXXt2lW5cuXShQsXtGfPHs2dO9c9cmacdevWqUSJEgn+SADgLrl/438AeBDFjYL41VdfmZ49e5oMGTIYh8NhKlWqZDZu3OhVfuvWraZFixYmY8aMxm63m/DwcFO1alUzbtw4j3IjR440uXPnNr6+vl6jr82ZM8dIMjVq1PBYpnPnzkaS+eSTT7ze1+l0muHDh5vixYubgIAAExwcbAoWLGiee+4589dff3mUnT17tqlSpYpJkyaNcTgcJmfOnKZ58+Zm2bJl7jIJjcSX0GhnN4obcTChv/hG0vv4449N/vz5jb+/v8mRI4fp37+/1wN9c+bMmeA6c+bMmaQ6xTcKYtwIcfH93TxS5Z49e0zjxo1NmjRpTFBQkKlWrZrZtGmTR5m4kd8S+kvoYb9xkjMK4qFDh0yzZs1MSEiISZ06taldu7bZvn2710OTExoJMO74vnE7o6OjTe/evU3GjBlNQECAKVeunFm7dm2SHsSc3G2/cOGC6dmzpwkPDzf+/v6mWLFiZtq0aR5lbud4iq9O8Y2CmNh6b7ZkyRJTrlw5ExAQYEJDQ027du28HrwcN3poQn83jkzocrnMF198YUqXLm3SpUtn0qRJY0qWLGlGjx4d78Osb7Znzx5js9m8RipNaBTERx991Gsd7du39/rsnD171rz44osmR44cxm63m4wZM5p69eqZnTt3euy3mx/E/Ouvv5oKFSqYVKlSmaxZs5r+/fub8ePHe9Rl7dq1pkmTJiZnzpzG4XCY9OnTm4iICPPjjz96rCu+9RtjzO7du937MqGRGvfu3Ws6duxosmbNaux2u8mQIYOpUKGCGTRokEe5CxcumKCgIDNixIh41wPg7rEZw8MeAADAgy9u5NOFCxfe76o8cCZMmKAXX3xRBw8e5AoYcI8RwAAAwENh+/btKlmypNasWeNx7xUSFxMTo8KFC6t9+/bq16/f/a4O8NBjGHoAAPBQKFKkiCZOnBjvKK1I2MGDB/X000+rd+/e97sqwH8CV8AAAAAAwCJcAQMAAAAAixDAAAAAAMAiBDAAAAAAsAgPYr5JbGysjhw5otSpU8tms93v6gAAAAC4T4wxunDhgrJkySIfn7tz7YoAdpMjR44oe/bs97saAAAAAFKIgwcPKlu2bHdlXQSwm6ROnVrS9Z2cJk2a21qH0+nUkiVLVLNmTdnt9rtZPdwB2iVlol1SHtokZaJdUibaJWWiXVKmB7Fdzp8/r+zZs7szwt1AALtJXLfDNGnS3FEACwoKUpo0aR6Yg+u/gHZJmWiXlIc2SZlol5SJdkmZaJeU6UFul7t5axKDcAAAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYJEHJoANHjxYFSpUUFBQkNKlSxdvmQMHDqhBgwZKlSqVwsLC1LNnT127ds3aigIAAABAAvzudwWS6tq1a3ryySdVvnx5TZgwwWu+y+VSvXr1lCFDBv3yyy86ffq02rdvL2OMRo0adR9qDAAAAACeHpgANnDgQEnSpEmT4p2/ZMkS7dixQwcPHlSWLFkkSSNGjFCHDh00ePBgpUmTxqqqAgAAAEC8HpguiLeydu1aFSlSxB2+JKlWrVqKjo7Wpk2b7mPNAAAAAOC6B+YK2K0cO3ZMmTJl8pgWEhIif39/HTt2LMHloqOjFR0d7X59/vx5SZLT6ZTT6bytusQtd7vL496gXVIm2iXloU1SJtolZaJdUibaJWV6ENvlXtT1vgawAQMGuLsWJmTDhg0qXbp0ktZns9m8phlj4p0e5/3334+3DkuWLFFQUFCS3jchS5cuvaPlcW/QLikT7ZLy0CYpE+2SMtEuKRPtkjI9SO1y+fLlu77O+xrAXnjhBbVs2TLRMrly5UrSusLDw7V+/XqPaWfPnpXT6fS6Mnajvn376uWXX3a/Pn/+vLJnz66aNWve9n1jTqdTS5cuVY0aNWS3229rHbj7aJeUiXZJeWiTlIl2SZlol5SJdkmZHsR2iesddzfd1wAWFhamsLCwu7Ku8uXLa/DgwTp69KgyZ84s6fpVLIfDoVKlSiW4nMPhkMPh8Jput9vv+MC4G+vA3Ue7pEy0S8pDm6RMtEvKRLukTLRLyvQgtcu9qOcDcw/YgQMHdObMGR04cEAul0tbtmyRJD3yyCMKDg5WzZo1VbhwYbVt21bDhg3TmTNn1KdPH3Xu3JkREAEAAACkCA9MAHv77bc1efJk9+uSJUtKklasWKHIyEj5+vpq/vz56tatmypWrKjAwEC1bt1aw4cPv19VBgAAAAAPD0wAmzRpUoLPAIuTI0cOzZs3z5oKAQAAAEAyPTTPAQMAAACAlI4ABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAA8Xo52KjnEp1hgt+ekn9XzpZfe8cePGadKkSbLZbJo+fbokaefOnerQoYMkqUOHDtq+fbskqWfPnnr33Xe1b98++fv7a/fu3ZKkRYsWacCAAZKks2fPqlWrVoqIiNATTzyhlStXSpKeffZZrV+/XpI0fPhwNW3aVJLkcrncI6LnypVLQ4YMkSRdvXpVkZGR92yf3C0EMAAAAACSpMvXYnT28jV9tHynyg1frLwD5qjb9A3adOC0zl6+psvXYtxlc+fOrdGjRye4rnfeeUc2m01vvfWWJKlQoUKaNWuWV7kePXqoXbt2WrVqlb7//nt1795dZ86cUbly5dwBbOvWre7y27dvV5EiRSRJ6dKl08yZMxUdHX1Xtt8KBDAAAAAAuup0aczq3crUd6benr9NWw6d1b7Tl/T3yQta888pZeo7U2NW71aMK1aSFBoaqhIlSmjJkiVe6/r000+1Z88ejRw50j2tYMGCio2N1c6dO93TXC6Xdu/erTp16kiSwsPD1aRJE82fP19ly5bVunXrrtft6lXlzZtXBw4c0Lp161SuXDlJkp+fn5566imP5wWndAQwAAAA4D/u8rUYjVq1S6/O3izn/wesmzldsXp19mat2H1c0TEuSVLv3r01YsQIr7JTp05Vz549ZbPZPKY3btxYH374ofv1qVOnlClTJo8y2bNn15EjR1SkSBHt2LFDx48fV+bMmVWmTBmtX79e69evdwcwSerSpYvGjx+v2Nj4653SEMAAAACA/7irTpf6zd0a/0xff8nldL+cvXmv/PwDJF2/ByssLEwbNmzwWGTChAnq2LGjDh065DG9cOHC2rdvnw4fPixJCgsL04kTJzzKHDp0SFmyZJGPj49CQ0M1b948lSlTxh3Atm3bpuLFi7vLp06dWjVq1NDMmTNve/utRAADAAAA/sMuRjs1ZvXuBK98KV24dHKf9P9XmGKP7NKWK0GKNUaS9Oqrr2ro0KEei+TPn19jxoxR06ZNdeHCBY95PXr0cHdN9PX1Vb58+dzdGI8fP64ffvhB9erVkySVLVtWo0aNUtmyZZUzZ05t3bpVwcHB8vPz81jniy++qE8++eROdoNlCGAAAADAf5jd10ezth5MuEBAsFSwsvTDu9Ksd6SwHPrfWYdsut69sHjx4sqWLZvXYpUqVdKLL76oFi1aKCbm38E76tevL5fL5X49atQoTZw4UZGRkWrWrJlGjx6t0NBQSdcD2IEDB5QvX77rVQkI0OOPP+71XhkzZlTp0qVva/ut5nfrIgAAAAAeVnZfH0VduZZ4oUerXP/7f1FXnNqz8d9uhwsXLnT//6RJk9z/36ZNG7Vp00aSNH36dC1YsEA2m007duxwlwkJCdG0adPifdvGjRurcePG7tdz5871mL9x40b3/3/66aeJb0MKwRUwAAAA4D/M6YpVukD/ZC2TLtCecJdFJIoABgAAAPyHOV2xalo8e7KWaVoiOwHsNhHAAAAAgP+wYIdd3Svnl903adHA7uuj7pULKNhhv8c1ezgRwAAAAID/uAC7rwY3KH7rgpLea1BcDj9ixO1iEA4AAADgPy7I3089IwrIJumNuVvj7V5o9/XRew2Kq0dEATnsvtZX8iFBAAMAAAAgh91X3Srn17MVHtGY1bs0a8tBRV1xKl2gXU1LZFf3ygXk8PMhfN0hAhgAAAAASdevhAX5S72qFNQr1QvL7usjpytWTlcs93zdJQQwAAAAAB5uDFsOP185/Ljqdbdw9xwAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAMB/zMVop6JjXPpn7141bdZMF6OdkqRFixZpwIABkqTIyEhVrlxZ1apVU4MGDbR9+3av9bzwwgt64oknVK5cOS1evFiStGbNGhUpUkTh4eHucps2bVKVKlXUr18/tWrVSk7n9fc7dOiQGjZsqMjISA0cODDBdX7++eeKjIxUZGSkMmXKpDlz5tyzfXOv+d3vCgAAAACwxuVrMYqOidXoVbs0a+tBnTx6SBd3H9dHy3fqhYgCuup0eZRfsGCBgoODtW3bNrVo0UK//fabAgIC3PNffvll5cmTR2fPnlWtWrVUq1YtPfroo/r1119VuXJld7msWbNq/vz5WrlypdasWaPZs2frySef1CuvvKJPP/1UWbNmTXSdXbp0UZcuXSRJxYsXV40aNe7xnrp3uAIGAAAA/Adcdbo0ZvVuZeo7U2/P36Yth87q8NnLOnflmt6ev02Z+s7UvO2HFOOK9Vq2WLFiKl26tDZs2OAxPU+ePJIkh8MhH5/r0SJt2rQKCgryKBceHu6eZrfb5efnJ6fTqX379ql3796qWrWq1qxZk+A642zevFkFChTwWv+DhCtgAAAAwEPu8rUYjVm9W6/O3uw98/BO6YdBckqaEH1JNeo20OVrMV7FsmTJoiNHjsS7/n79+qlnz563rMfJkye1fPly9e/fX6dOndK2bds0Y8YM+fn5qWHDhvr1118TXeeMGTP05JNP3vJ9UjICGAAAAPCQu+p0qd/crfHPzFpQqv3i9f/fv1U/7fpb0THeV8GOHDmievXqeU2fOHGirl27ptatWydah/Pnz2vkyJGaPn267Ha70qVLp/z58ytbtmySJD8/P8XExMjPzy/BdS5YsED9+vVLwhanXAQwAAAA4CF2MdqpMat3yxlP18L4xBqjMat3yRVr3NO2b9+uTZs26fPPP/cou2LFCs2cOVOzZ89OdJ0ul0vt2rVTixYtlD9/fklSYGCg0qVLp3PnzsnPz0/Xrl2Tn59fguvcsmWL8uXLp1SpUiVpO1IqAhgAAADwELP7+mjW1oPJWmbWloMKtkl169aV3W5XUFCQpk+f7jEAhyQ9//zzCg4OVvXq1RUYGKiFCxfqzz//VI8ePbR7925Vr15dw4YN086dO7Vu3Trt379fP/30k7p166annnpKgwcPVv369eV0OvXuu+8muE7p4eh+KBHAAAAAgIea3ddHUVeuxT8zTYZ/ux9KUs7iUs7iirri1MaVK+VjsyW67l27dnlNK1SokJYtW+YxrWTJkmrevLkWLFjgDnWSVKFCBf3888+3XKckDR48ONG6PCgYBREAAAB4iDldsUoX6J+sZdIF2pPcZRHJQwADAAAAHmJOV6yaFs+erGWalshOALtHCGAAAADAQyzYYVf3yvll903aV3+7r4+6Vy6gYIf9Htfsv4kABgAAADzkAuy+GtygeJLKvteguBx+xIR7hUE4AAAAgIdckL+fekYUkE3SG3O3xtu90O7ro/caFFePiAJy2H2tr+R/BAEMAAAA+A9w2H3VrXJ+PVvhEY1ZvUuzthxU1BWn0gXa1bREdnWvXEAOPx/C1z1GAAMAAAD+I4L8/RTkL/WqUlCvVC8su6+PnK5YOV2x3PNlEQIYAAAA8B9zY9hy+PnK4cdVL6twdx0AAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABbxu98VABJyxRkjX5tNfr4+inHFymWMAu0csgAAAHhw8W0WKc6VazG6GhOrMat3aeaWg4q6ck3pAv3VrER2da9cQAF+Pgr059AFAADAg4dvsUhRomNcGvPzbr3x41Y5XbE3zLmkLYfO6p2F2/Vew+LqEVFADj/f+1ZPAAAA4HYQwJBiXLkWozE/79YrP2xOsIzTFatXftgsm2zqVikfV8IAAADwQGEQDqQYV2NceuPHrUkq2/fHLboaE3vrggAAAEAKQgBDinDFGaMxq3ff1O0wYU5XrMau3q0rzph7XDMAAADg7iGAIUXwtdk0c8vBZC0zc8sB+dhs96hGAAAAwN1HAEOK4Ofro6gr15K1TNQVp+y+HMIAAAB4cPDtFSlCjCtW6QL9k7VMukB7krssAgAAACkBAQwpgssYNSuRPVnLNCuRQ7HG3KMaAQAAAHcfAQwpQqDdT90r509yl0K7r4+6Vc6vQDvD0AMAAODBQQBDihHg56v3GhZPUtkPGpVQgB+HLwAAAB4sXD5AihHo76ceEQVkk019f9wS7/1ddl8fvd+whLpXzi+Hn+99qCUAAABw+whgSFEcfr7qVimfOpbPq7Grd2vmlgOKuuJUukC7mpXIoW6V8yvAz4fwBQAAgAfSA9GHa9++fXr22WeVO3duBQYGKm/evOrfv7+uXfMctvzAgQNq0KCBUqVKpbCwMPXs2dOrDFK+QH8/hQT56+VqBbW2Ty3tGdBQa/vU0svVCiokyF+B/vxuAAAAgAfTA/FNdufOnYqNjdVnn32mRx55RNu3b1fnzp116dIlDR8+XJLkcrlUr149ZciQQb/88otOnz6t9u3byxijUaNG3ectwO24cYANrngBAADgYfBABLDatWurdu3a7td58uTRrl279Omnn7oD2JIlS7Rjxw4dPHhQWbJkkSSNGDFCHTp00ODBg5UmTZr7UncAAAAAiPNABLD4nDt3TqGhoe7Xa9euVZEiRdzhS5Jq1aql6Ohobdq0SVWqVIl3PdHR0YqOjna/Pn/+vCTJ6XTK6XTeVt3ilrvd5XFv0C4pE+2S8tAmKRPtkjLRLikT7ZIyPYjtci/qajPmwXuS7d9//63HHntMI0aMUKdOnSRJXbp00b59+7RkyRKPsg6HQ5MmTVKrVq3iXdeAAQM0cOBAr+lTp05VUFDQ3a88AAAAgAfC5cuX1bp1a507d+6u9ai7r1fAEgo/N9qwYYNKly7tfn3kyBHVrl1bTz75pDt8xbHZbF7LG2PinR6nb9++evnll92vz58/r+zZs6tmzZq3vZOdTqeWLl2qGjVqyG6339Y6cPfRLikT7ZLy0CYpE+2SMtEuKRPtkjI9iO0S1zvubrqvAeyFF15Qy5YtEy2TK1cu9/8fOXJEVapUUfny5fX55597lAsPD9f69es9pp09e1ZOp1OZMmVKcP0Oh0MOh8Nrut1uv+MD426sA3cf7ZIy0S4pD22SMtEuKRPtkjLRLinTg9Qu96Ke93UY+rCwMBUsWDDRv4CAAEnS4cOHFRkZqccee0wTJ06Uj49n1cuXL6/t27fr6NGj7mlLliyRw+FQqVKlLN0uAAAA4EFwMdqp6BiX/tm7VzabTSt+/p8kadGiRRowYIAkKSoqSh06dFBkZKQqVaqk5557TnF3Mf3www+KiIhQpUqVVLduXR0+fNhj/U2bNlVkZKQiIiKUMWNGSdL777+vChUqqGzZspo8ebKk61eaGjZsqCpVqqh3796SpFOnTqlixYqKiIhQlSpVdOTIESt2yT33QAzCceTIEUVGRipHjhwaPny4Tp486Z4XHh4uSapZs6YKFy6stm3batiwYTpz5oz69Omjzp07MwIiAAAAcIPL12IUHROr0at2adbWgzp59JACMubQC6/31y9LF+iq0+Uu26NHD7Vq1Up169aVJP38888yxrhHJV+0aJECAwP1zz//eD2Dd9asWZKkX375RV988YUk6amnntLbb7+ta9eu6bHHHlO7du302WefqVGjRnr22WfVrVs3rV+/XqVLl9bq1avl6+uryZMna8KECXrrrbcs2kP3zgMRwJYsWaI9e/Zoz549ypYtm8e8uPTt6+ur+fPnq1u3bqpYsaICAwPVunVr9zD1AAAAAKSrTpfGrN6tfnO3yumKvT7x/GUpdSbtOHJWGZ/7RO0Lp1a4K1Yul0t79uxxhy9JqlSpkiTpu+++U48ePRQYGCjp+qOiEjJjxgw1a9ZMxhh3ObvdLj+/63Hkn3/+UdWqVSVJjz32mH7++WeVLVvWvfz58+dVpEiRu7cT7qP72gUxqTp06CBjTLx/N8qRI4fmzZuny5cv6/Tp0xo1alS893cBAAAA/0WXr8Vo1KpdenX25n/D141K1lPMpnmasOZv/br/tA4cOaawsDD37MjISBUpUkS7d+/W0aNHPR4BlRBjjH766SdVq1bNY/onn3yiFi1ayGazqVChQlq+fLkkadmyZYqKipIk/f777ypbtqxGjx6tkiVL3v6GpyAPRAADAAAAcOeuOl3qN3drwgWyFJDOn5QundVPu44pdbpQj9t/Vq5cqdKlS+vatWvKkiWL1z1f8VmzZo1Kly4tf39/97SlS5dq1apVev311yVJnTp10h9//KHq1asrODjYfZtR0aJFtX79er377rv64IMPbnOrUxYCGAAAAPAfcDHaqTGrd8d/5etGxWtJWxcp1hiN+98e5c6TVwsWLHDPjomJkSS1aNFCo0eP1pUrVyRJ+/bt0969e71WN2PGDD355JPu13/88YfeffddTZkyxT2wXlBQkCZNmqRly5ZJkurXr+9xP1natGmVKlWq29vwFOaBuAcMAAAAwJ2x+/po1taDty6Y6zFp7XRJ0qwtB7Xg44/1Wp/eGjJkiAICApQ7d27lypVLwcHBev7551WrVi1JUpo0abweFWWM0bJlyzR06FD3tFdffVWnT59W/fr1JUlz5szR3r171atXL/n6+qpdu3bKlSuXNm3apJdeekm+vr4KCgrShAkT7tKeuL+4AgYAAAD8B9h9fRR15Vr8M9NkkGq/eP3/bTap9VCpTDNFXXEqY1h6TZ48WatWrdLixYs1btw4BQcH61K0U/UaNtLKVav0Zv/+ypsvv9JnvP783XHjxmnSpEny8fHRW2+9JX9/f+3cuVMff/yx5s+fr8cff1yjR4/WypUr9dZbb2nu3LmaNGmSli9froIFC0qSTp48qapVq2rFihX6+uuv9dJLLykiIkJPPPGEVq5cKUl69tln3c8CHj58uJo2bSpJcrlc7nvGcuXKpSFDhkiSrl69qsjIyHuwd5OOAAYAAAD8BzhdsUoX6H/rgjdIF2j36rJ4+VqMzl6+po9W7FS54YuVd8AcdZu+QRsPnNaFq05dio6RM+b6MPa5c+fW6NGjE1z/O++8I5vN5h5evnDhwh5Xy+L06NFD7dq106pVq/T999+re/fuOnPmjMqVK+cOYFu3/ntv2/bt292jJqZLl04zZ85UdHR0srb9XiGAAQAAAP8BTlesmhbPnqxlmpbI7hHArjpdGvvzbmXqO1NvzdumLYfOat/pS/r75AWt+eeUsvT7QaNX71KMkWJcsQoNDVWJEiW0ZMkSr3V/+umn2rNnj0aOHOmeVqhQIcXExGjnzp3uaS6XS7t371adOnUkXX8OcJMmTTR//nyVLVtW69atu163q1eVN29eHThwQOvWrVO5cuUkSX5+fnrqqafcD32+3whgAAAAwH9AsMOu7pXzy+6btAhg9/VR98oFFOywS7p+5Wv06l165YcEhrDX9ZD3+pwt+nnPCV26FqNYY9S7d2+NGDHCq+zUqVPVs2dP2Ww2j+mvvPKKhg0b5n596tQpZcqUyaNM9uzZdeTIERUpUkQ7duzQ8ePHlTlzZpUpU0br16/X+vXr3QFMkrp06aLx48crNvYWA5BYgAAGAAAA/EcE2H01uEHxJJV9r0FxOfz+jQtXnS698WMCQ9j7+ksup/vlnM17FRBw/QHNuXLlUlhYmDZu3OixyIQJE9SxY0cdOnTIY/oTTzyhvXv3uoe4DwsL04kTJzzKHDp0SFmyZJGPj49CQ0M1b948lSlTxh3Atm3bpuLF/93O1KlTq0aNGpo5c2aStv1eIoABAAAA/xFB/n7qGVFAwxqXTPBKmN3XR8Mal1SPiAIK8r8+aPrFaKfGJjaEfbpw6eQ+6f+vMMUe2aXt0cG6FhOrK84Yvfrqq15XwfLnz68xY8aoadOmunDhgse8Xr16ubsm+vr6Kl++fO5ujMePH9cPP/ygevXqSZLKli2rUaNGqWzZssqZM6e2bt2q4OBg+fl5Dvj+4osv6pNPPknyvrpXCGAAAADAf4jD7qtulfPr+PvN9G79YiqZLUS50werZLYQvVu/mI6/30zdKueXw+7rXsbu66OZiQ1hHxAsFaws/fCuNOsdKSyH/hflkN3XRz42m4oXL65s2bJ5LVapUiW9+OKLatGihfv5YpLUoEEDuVwu9+tRo0Zp4sSJioyMVLNmzTR69GiFhoZKuh7ADhw4oHz58l2vSkCAHn/8ca/3ypgxo0qXLp3s/XW38RwwAAAA4D8myN9PQf5SryoF9Ur1wrL7+sjpipXTFeu+5+tGiQ5hH+fRKtf//l/UFad2b9ggH5/r93jNnTvX/UDnSZMmucu1adNGbdq0kSR9//33kiSbzaYdO3a4y4SEhGjatGnxvm3jxo3VuHFj9+u5c+d6zL+x6+Onn36a+DZYgCtgAAAAwH9UsMMuh5+vfGw2Ofx84w1f0u0PYX/pWkzC3Rb/owhgAAAAABLldMWqWYnkDWHfpHh2HY66olhj7lGtHkwEMAAAAACJCnbY1a1S8oaw71zxEWUPCVKgnbuebkQAAwAAAHBLAXZfvdcwaUPYD6p/vZyfj+0WJf97iKMAAAAAbinI3089KheQTTb1/XFLvPd22X19NKh+cXWtlE8OPx/5+/nGs6b/NgIYAAAAgCRx2H3VtVI+dSyfV2NX79bMLQcUdcWpdIF2NSmeXV0r5VOg3U++NhG+EkAAAwAAAJBk/w5hX0B9qheS3cdHzthYxbiM/Hyvj6aIhBHAAAAAACRbqhuGrHf4+MpBskgSBuEAAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgSwFOpitFPRMS79s3evmjZrpovRTknSokWLNGDAAElSZGSkKleurGrVqqlBgwbavn17ktY9efJkVapUSeXKldMrr7wiSdq0aZMqVaqkiIgItWjRQk7n9ferXLmyIiMjVaFCBY/1x8bGqnDhwho9evRd3GoAAADg4eZ3vysAT5evxSg6JlajV+3SrK0HdfLoIV3cfVwfLd+pFyIK6KrT5VF+wYIFCg4O1rZt29SiRQv99ttvCggISPQ9Wrdurfbt20uSqlatqoMHDypr1qxavHixgoKC9MYbb2j27Nl68skn9dNPP8lut2vVqlX66KOPNGHCBEnStGnTlCNHjnuzEwAAAICHFAEsBbnqdGnM6t3qN3ernK7Y6xPPX5auXNPb87fp3UXb1S78vMLj5t2gWLFiKl26tDZs2KBKlSol+j52u12SFBMTo7Rp0yp9+vQKCgrymO/n5+dR9vz58ypatKgkyeVyacaMGWrRooUuX758x9sNAAAA/FfQBTGFuHwtRqNW7dKrszf/G77iHN4p/TBIzu/f0YQRg/Xr/tO6fC3Gax1ZsmTRkSNHkvR+w4YNU/78+b3C14EDB7Rs2TLVr19fknTy5ElVrFhR3bp1U+XKlSVJ33zzjZ588kn5+HD4AAAAAMnBN+gU4qrTpX5zt8Y/M2tBqcmb1//Kt9RPu44pOsb7KtiRI0eUJUuWJL3fK6+8or/++ksnTpzQunXrJF2/ytW2bVtNnDjRfeUrQ4YM+t///qeZM2fqjTfekMvl0vTp09WyZcvb21AAAADgP4wuiCnAxWinxqze7X3lKwGxxmjM6l1yxRr3tO3bt2vTpk36/PPPb7l8dHS0HA6HfH19lSpVKgUFBcnlcqlNmzZ6++23lT9/fknXuyj6+PjIx8dHadOmVapUqXTs2DEdP35c9erV0+HDh+VyuVS+fHmVKlXq9jYeAAAA+A8hgKUAdl8fzdp6MFnLzNpyUME2qW7durLb7QoKCtL06dNvOQCHJA0dOlQ//fSTYmJiVL16dRUrVkzTpk3TmjVrdOHCBb377rvq2rWrnnjiCbVu3dodwsaMGaOsWbNq48aNkqRJkybp4sWLhC8AAAAgiQhgKYDd10dRV67FPzNNBqn2i/++zllcyllcUVec2rhypXxstmS/31tvvaW33nrLY1qrVq3UqlUrr7KrVq1KcD0dOnRI9nsDAAAA/2XcA5YCOF2xShfon6xl0gXak9xlEQAAAEDKQABLAZyuWDUtnj1ZyzQtkZ0ABgAAADxgCGApQLDDru6V88vum7TmsPv6qHvlAgp22O9xzQAAAADcTQSwFCLA7qvBDYonqex7DYrL4UfTAQAA4OFxMdqp6BiXYo3Rkp9+Us+XXnbPGzdunCZNmiSbzabp06dLknbu3Okek6BDhw7avn27JKlnz5569913tW/fPtlsNq1fv16StGjRIg0YMECSdPbsWbVq1UoRERF64okntHLlSknSs88+6y4/fPhwtWnTRpLkcrlUsmRJSVKuXLk0ZMgQSdLVq1cVGRmZrO3kW3wKEeTvp54RBTSscckEr4TZfX00rHFJ9YgooCB/xk8BAADAg+/ytRidvXxNHy3fqXLDFyvvgDnqNn2DNh04rbOXr+nytRh32dy5c2v06NEJruudd96RzWZzDzhXuHBhDR061Ktcjx491K5dO61atUrff/+9unfvrjNnzqhcuXLuALZ167/P6N2xY4eKFCkiSUqXLp1mzpyp6Ojo29pevsWnIA67r7pVzq9nKzyiMat3adaWg4q64lS6QLualsiu7pULyOHnI4fd935XFQAAALhjV50ujVm9W/3mbvUc3+DkBf2975Qy9Z2pwQ2KK/D/54WGhqpEiRJasmSJcuTI4bGuTz/9VBcuXNDkyZPd0woVKiSn06mdO3e6p7lcLu3evVt16tSRJIWHh6tJkyaaP3++ypYtqw8++EA9e/bU1atXlTt3bknShg0bVK5cOUmSn5+fnnrqKU2ePFnt2rVL9jZzBSyFCfL3U0iQv3pVKai1fWppz4CGWtunlnpVKaiQIH+ufAEAAOChcPlajEat2qVXZ29OcHA5pytWr87erBW7jys6xiVJ6t27t0aMGOFVdurUqerZs6dsNz2m6ZVXXtGwYcPcr0+dOqVMmTJ5lMmePbuOHDmiIkWKaMeOHTp+/LgyZ87sft7tpk2b3AFMkrp06aLx48crNjb5g+IRwFKoYIddDj9f+dhscvj5MuAGAAAAHipXnS71m7s1/pm+/pLL6X45e/Ne+fkHSLp+D1ZYWJg2bNjgsciECRPUsWNHHTp0yGP6E088ob179+rw4cOSpLCwMJ04ccKjzKFDh5QlSxb5+PgoNDRU8+bNU5kyZdwBbPv27Spe/N/xGlKnTq0aNWpo5syZyd5uAhgAAAAAS12MdmrM6t0JP1YpXbh0cp/0/1eYYo/s0pYrQYo1RpL06quvet3blT9/fo0ZM0ZNmzbVhQsXPOb16tVLI0eOlCT5+voqX758WrJkiSTp+PHj+uGHH1SvXj1JUtmyZTVq1CiVLVvW3c0xODhYfn6ePdFefPFFffLJJ8nedgIYAAAAAEvZfX00a+vBhAsEBEsFK0s/vCvNekcKy6H/nXXIpuvdC4sXL65s2bJ5LVapUiW9+OKLatGihWJi/h28o0GDBnK5XO7Xo0aN0sSJExUZGalmzZpp9OjRCg0NlXQ9gB04cED58uVzl48bAfFGGTNmVOnSpZO97dxQBAAAAMBSdl8fRV25lnihR6tc//t/UVec2rPx326HCxcudP//pEmT3P/fpk0b9/Dx33//vSTJZrNpx44d7jIhISGaNm1avG/buHFjNW7c2GPaoEGD3P+/ceNG9/9/+umniW9DPLgCBgAAAMBSTles0gX6J2uZdIH2hLssPkAIYAAAAAAs5XTFqmnx7MlapmmJ7AQwAAAAAEiuYIdd3Svnl903aXHE7uuj7pULPBQjgxPAAAAAAFguwO6rwQ2K37qgpPcaFJfD7+GILgzCAQAAAMByQf5+6hlRQDZJb8zdGm/3Qruvj95rUFw9IgrIYfe1vpL3AAEMAAAAwH3hsPuqW+X8erbCIxqzepdmbTmoqCtOpQu0q2mJ7OpeuYAcfj4PTfiSCGAAAAAA7qMgfz8F+Uu9qhTUK9ULy+7rI6crVk5X7ENxz9fNCGAAAAAA7rsbw5bDz1cOv4fnqteNHo472QAAAADgAUAAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALOJ3vysAAACA+F1xxsjHZpPd10dOV6xiXEZ+vjY5/Hzvd9UA3KYH5gpYw4YNlSNHDgUEBChz5sxq27atjhw54lHmwIEDatCggVKlSqWwsDD17NlT165du081BgAAuD1XrsXo7OVrGvHTnyo3fLHyDpijcsMXa8TyP3XhqlOXomN09VrM/a4mgNvwwFwBq1Klit544w1lzpxZhw8fVp8+fdS8eXOtWbNGkuRyuVSvXj1lyJBBv/zyi06fPq327dvLGKNRo0bd59oDAAAkTXSMS2N+3q03ftwqpyv2hjmXtOXQWQ1atF3v1i+mrpXyyyfGJX+uhgEPlAcmgL300kvu/8+ZM6def/11NW7cWE6nU3a7XUuWLNGOHTt08OBBZcmSRZI0YsQIdejQQYMHD1aaNGnuV9UBAACS5Mq1GI35ebde+WFzgmWcrli9PmeLbLKpXdncShtgV6D/A/OVDvjPe2C6IN7ozJkz+uabb1ShQgXZ7XZJ0tq1a1WkSBF3+JKkWrVqKTo6Wps2bbpfVQUAAEiyqzEuvfHj1iSVfXPe9XIxseZeVgnAXfZA/Vzy2muvafTo0bp8+bLKlSunefPmuecdO3ZMmTJl8igfEhIif39/HTt2LMF1RkdHKzo62v36/PnzkiSn0ymn03lb9Yxb7naXx71Bu6RMtEvKQ5ukTLRLynQ32+WqM0afrtotP8Uqab0KYzXhl91qWCybcoUGKcD+QH2tu6f4vKRMD2K73Iu62owx9+1nkwEDBmjgwIGJltmwYYNKly4tSTp16pTOnDmj/fv3a+DAgUqbNq3mzZsnm82mLl26aP/+/Vq8eLHH8v7+/poyZYpatmyZrDpMnTpVQUFBt7llAAAAAB50ly9fVuvWrXXu3Lm7dkvTfQ1gp06d0qlTpxItkytXLgUEBHhNP3TokLJnz641a9aofPnyevvttzVnzhxt3frvZfuzZ88qNDRUy5cvV5UqVeJdf3xXwLJnz65Tp07d9k52Op1aunSpatSo4e4iifuPdkmZaJeUhzZJmWiXlOlutkusMSr+/gIdOHMpycvkDA3Wb6/Vlo+PTT422x29/8OEz0vK9CC2y/nz5xUWFnZXA9h9vVYdFhamsLCw21o2LjfGhafy5ctr8ODBOnr0qDJnzixJWrJkiRwOh0qVKpXgehwOhxwOh9d0u91+xwfG3VgH7j7aJWWiXVIe2iRlol1SprvRLtdiXAp0+OuKK+kBLNBh1zVjU4CPr+yMhuiFz0vK9CC1y72o5wMxCMevv/6q0aNHa8uWLdq/f79WrFih1q1bK2/evCpfvrwkqWbNmipcuLDatm2rzZs366efflKfPn3UuXNnRkAEAAApnssYNSuRPVnLNCmeXYejrij2/nVoApBMD0QACwwM1KxZs1StWjUVKFBAHTt2VJEiRbRq1Sr31StfX1/Nnz9fAQEBqlixolq0aKHGjRtr+PDh97n2AAAAtxZo91P3yvll903a1zO7r486V3xE2UOCFMgAHMAD44H4tBYtWlTLly+/ZbkcOXJ4jIwIAADwIAnw89V7DYsn+hywOIPqF5ck+flw7xfwIHkgAhgAAMB/QaC/n3pEFJBNNvX9cYucrlivMnZfHw2qX1xdK+WTw89H/tz7BTxQCGAAAAApiMPPV90q5VPH8nk1dvVuzdxyQFFXnEoXaFeT4tnVtVI+Bdr95GsT4Qt4ABHAAAAAUphAfz8F+ksvVyuoPtULye7jI2dsrGJcRn6+NjkIXsADiwAGAACQQt04uIbDx1cOvrkBD7wHYhREAAAAAHgYEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiBDAAAAAAsAgBDAAAAAAsQgADAAAAAIsQwAAAAADAIgQwAAAAALAIAQwAAAAALEIAAwAAAACLEMAAAAAAwCIEMAAAAACwCAEMAAAAACxCAAMAAAAAixDAAAAAAMAiyQpgZ8+e1ahRo3T+/HmveefOnUtwHgAAAAAgmQFs9OjRWr16tdKkSeM1L23atPr55581atSou1Y5AAAAAHiYJCuAzZw5U88//3yC85977jl9//33d1wpAAAAAHgYJSuA/f3338qXL1+C8/Ply6e///77jisFAAAAAA+jZAUwX19fHTlyJMH5R44ckY8P43oAAAAAQHySlZZKliyp2bNnJzj/hx9+UMmSJe+0TomKjo5WiRIlZLPZtGXLFo95Bw4cUIMGDZQqVSqFhYWpZ8+eunbt2j2tDwAAAAAklV9yCr/wwgtq2bKlsmXLpq5du8rX11eS5HK5NHbsWH300UeaOnXqPalonFdffVVZsmTR1q1bPaa7XC7Vq1dPGTJk0C+//KLTp0+rffv2MsYwMAgAAACAFCFZAaxZs2Z69dVX1bNnT/Xr10958uSRzWbT33//rYsXL+qVV15R8+bN71VdtXDhQi1ZskQzZ87UwoULPeYtWbJEO3bs0MGDB5UlSxZJ0ogRI9ShQwcNHjw43pEbAQAAAMBKyQpgkjR48GA1atRI33zzjfbs2SNjjCpXrqzWrVurTJky96KOkqTjx4+rc+fOmj17toKCgrzmr127VkWKFHGHL0mqVauWoqOjtWnTJlWpUiXe9UZHRys6Otr9Ou45Zk6nU06n87bqGrfc7S6Pe4N2SZlol5SHNkmZaJeUiXZJmWiXlOlBbJd7UVebMcbc9bXeZcYY1a1bVxUrVtSbb76pffv2KXfu3Nq8ebNKlCghSerSpYv27dunJUuWeCzrcDg0adIktWrVKt51DxgwQAMHDvSaPnXq1HiDHgAAAID/hsuXL6t169Y6d+7cXetRl6wrYEOHDlWPHj0UGBgoSVq9erXKli0rh8MhSbpw4YJee+01jR07NknrSyj83GjDhg1as2aNzp8/r759+yZa1mazeU0zxsQ7PU7fvn318ssvu1+fP39e2bNnV82aNW97JzudTi1dulQ1atSQ3W6/rXXg7qNdUibaJeWhTVIm2iVlol1SJtolZXoQ2yWud9zdlKwA1rdvX3Xo0MEdwOrXr68tW7YoT548kq4nxM8++yzJASxuUI/E5MqVS4MGDdK6devcQS9O6dKl1aZNG02ePFnh4eFav369x/yzZ8/K6XQqU6ZMCa7f4XB4rVeS7Hb7HR8Yd2MduPtol5SJdkl5aJOUiXZJmWiXlIl2SZkepHa5F/VMVgC7ubfinfZeDAsLU1hY2C3LffLJJxo0aJD79ZEjR1SrVi1Nnz5dZcuWlSSVL19egwcP1tGjR5U5c2ZJ1wfmcDgcKlWq1B3VEwAAAADuhmQPwnE/5MiRw+N1cHCwJClv3rzKli2bJKlmzZoqXLiw2rZtq2HDhunMmTPq06ePOnfuzAiIAAAAAFKEZD2IOSXz9fXV/PnzFRAQoIoVK6pFixZq3Lixhg8ffr+rBgAAAACSbuMK2Pjx491XoGJiYjRp0iR3N8ILFy7c3dolIFeuXPF2f8yRI4fmzZtnSR0AAAAAILmSFcBy5MihL774wv06PDxcX331lVcZAAAAAIC3ZAWwffv23aNqAAAAAMDDL9ldEGNjYzVp0iTNmjVL+/btk81mU548edSsWTO1bds20WduAQAAAMB/WbIG4TDGqEGDBurUqZMOHz6sokWL6tFHH9W+ffvUoUMHNWnS5F7VEwAAAAAeeMm6AjZp0iT9/PPP+umnn1SlShWPecuXL1fjxo01ZcoUtWvX7q5WEgAAAAAeBsm6AjZt2jS98cYbXuFLkqpWrarXX39d33zzzV2rHAAAAAA8TJIVwLZt26batWsnOL9OnTraunXrHVcKAAAAAB5GyQpgZ86cUaZMmRKcnylTJp09e/aOKwUAAAAAD6NkBTCXyyU/v4RvG/P19VVMTMwdVwoAAAAAHkbJGoTDGKMOHTrI4XDEOz86OvquVAoAAAAAHkbJCmDt27e/ZRlGQAQAAACA+CUrgE2cOPFe1QMAAAAAHnrJugcMAAAAAHD7CGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYBECGAAAAABYhAAGAAAAABYhgAEAAACARQhgAAAAAGARAhgAAAAAWIQABgAAAAAWIYABAAAAgEUIYAAAAABgEQIYAAAAAFiEAAYAAAAAFiGAAQAAAIBFCGAAAAAAYJEHJoDlypVLNpvN4+/111/3KHPgwAE1aNBAqVKlUlhYmHr27Klr167dpxoDAAAAgCe/+12B5HjnnXfUuXNn9+vg4GD3/7tcLtWrV08ZMmTQL7/8otOnT6t9+/YyxmjUqFH3o7oAAAAA4OGBCmCpU6dWeHh4vPOWLFmiHTt26ODBg8qSJYskacSIEerQoYMGDx6sNGnSWFlVAAAAAPDywHRBlKQhQ4Yoffr0KlGihAYPHuzRvXDt2rUqUqSIO3xJUq1atRQdHa1Nmzbdj+oCAAAAgIcH5grYiy++qMcee0whISH69ddf1bdvX+3du1fjx4+XJB07dkyZMmXyWCYkJET+/v46duxYguuNjo5WdHS0+/X58+clSU6nU06n87bqGrfc7S6Pe4N2SZlol5SHNkmZaJeUiXZJmWiXlOlBbJd7UVebMcbc9bUm0YABAzRw4MBEy2zYsEGlS5f2mj5z5kw1b95cp06dUvr06dWlSxft379fixcv9ijn7++vKVOmqGXLlsmqw9SpUxUUFJSMrQEAAADwMLl8+bJat26tc+fO3bVbmu5rADt16pROnTqVaJlcuXIpICDAa/rhw4eVLVs2rVu3TmXLltXbb7+tOXPmaOvWre4yZ8+eVWhoqJYvX64qVarEu/74roBlz55dp06duu2d7HQ6tXTpUtWoUUN2u/221oG7j3ZJmWiXlIc2SZlol5SJdkmZaJeU6UFsl/PnzyssLOyuBrD72gUxLCxMYWFht7Xs5s2bJUmZM2eWJJUvX16DBw/W0aNH3dOWLPm/9u49RsrybPz4tYfZYUWgkEUWysHTKy2iWNFa0KroK0o8BmNRqoXU0CpCS9Ue1Fjw1xclBU1atW0a8dAmBtuCFqFVsAjUCBYRlEqjRlDQQi0KggLLsvv8/rBMXTmIutwzC59PQsLOPDPPvV57J/t1Zh5mRT6fj759++72efL5fOTz+Z1uz+Vyn/kHozmeg+ZnLqXJXEqPmZQmcylN5lKazKU0taS57It1tojPgC1YsCAWLlwYAwYMiHbt2sWiRYvie9/7XlxwwQXRvXv3iIgYOHBg9OrVK6644oqYOHFivPPOO3H99dfHiBEjXAERAAAoCS0iwPL5fDz00ENxyy23RF1dXfTo0SNGjBgRP/jBDwrHVFRUxMyZM2PkyJFx8sknR3V1dQwdOjQmTZpUxJUDAAD8V4sIsOOPPz4WLlz4scd17949ZsyYkWBFAAAAn1yL+nfAAAAAWjIBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMAAAgEQEGAACQiAADAABIRIABAAAkIsAAAAASEWAAAACJCDAAAIBEBBgAAEAiAgwAACARAQYAAJCIAAMAAEhEgAEAACQiwAAAABIRYAAAAIkIMAAAgEQEGAAAQCICDAAAIBEBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMAAAgEQEGAACQiAADAABIRIABAAAkIsAAAAASEWAAAACJCDAAAIBEBBgAAEAiAgwAACARAQYAAJCIAAMAAEhEgAEAACQiwAAAABIRYAAAAIkIMAAAgEQEGAAAQCICDAAAIBEBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMAAAgEQEGAACQiAADAABIRIABAAAkIsAAAAASEWAAAACJCDAAAIBEBBgAAEAiAgwAACARAQYAAJCIAAMAAEhEgAEAACQiwAAAABIRYAAAAIkIMAAAgEQEGAAAQCICDAAAIBEBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMAAAgEQEGAACQiAADAABIRIABAAAkIsAAAAASEWAAAACJCDAAAIBEBBgAAEAiAgwAACARAQYAAJCIAAMAAEhEgAEAACQiwAAAABIRYAAAAIkIMAAAgEQEGAAAQCICDAAAIBEBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMAAAgEQEGAACQiAADAABIRIABAAAkIsAAAAASEWAAAACJCDAAAIBEWlSAzZw5M0466aSorq6OmpqaGDx4cJP7V61aFeeff360bt06ampq4jvf+U5s27atSKsFAABoqrLYC9hbU6dOjREjRsStt94aZ5xxRmRZFsuWLSvc39DQEOeee2507NgxnnrqqXj77bdj2LBhkWVZ3HnnnUVcOQAAwAdaRIBt3749vvvd78bEiRPjyiuvLNzes2fPwt9nzZoVy5cvj9WrV0eXLl0iIuL222+P4cOHx/jx46Nt27bJ1w0AAPBhLSLAnnvuuXjzzTejvLw8vvSlL8XatWvjuOOOi0mTJsXRRx8dERELFiyI3r17F+IrIuLss8+Ourq6WLx4cQwYMGCXz11XVxd1dXWFrzdu3BgREfX19VFfX/+p1rvjcZ/28ewb5lKazKX0mElpMpfSZC6lyVxKU0ucy75Ya1mWZVmzP2szmzJlSlx22WXRvXv3uOOOO+LQQw+N22+/PWbNmhUvv/xydOjQIb71rW/Fa6+9FrNmzWry2Hw+H/fff39cdtllu3zucePGxS233LLT7Q8++GAcdNBB++T7AQAASt/mzZtj6NCh8e677zbbO+qK+grY7uLnwxYtWhSNjY0REXHTTTfFxRdfHBER9913X3Tt2jV+//vfx7e//e2IiCgrK9vp8VmW7fL2HW644Ya49tprC19v3LgxunXrFgMHDvzU/5Hr6+tj9uzZcdZZZ0Uul/tUz0HzM5fSZC6lx0xKk7mUJnMpTeZSmlriXHa8O645FTXARo0aFZdeeukejzn00ENj06ZNERHRq1evwu35fD4OP/zwWLVqVURE1NbWxjPPPNPksevXr4/6+vro1KnTbp8/n89HPp/f6fZcLveZfzCa4zlofuZSmsyl9JhJaTKX0mQupclcSlNLmsu+WGdRA6ympiZqamo+9ri+fftGPp+Pl156KU455ZSI+KCgX3vttejRo0dERPTr1y/Gjx8fa9asic6dO0fEBxfmyOfz0bdv3333TQAAAOylFnERjrZt28ZVV10VY8eOjW7dukWPHj1i4sSJERFxySWXRETEwIEDo1evXnHFFVfExIkT45133onrr78+RowY4QqIAABASWgRARYRMXHixKisrIwrrrgitmzZEieddFLMmTMn2rdvHxERFRUVMXPmzBg5cmScfPLJUV1dHUOHDo1JkyYVeeUAAAAfaDEBlsvlYtKkSXsMqu7du8eMGTMSrgoAAGDvlRd7AQAAAAcKAQYAAJCIAAMAAEhEgAEAACQiwAAAABIRYAAAAIkIMAAAgEQEGAAAQCICDAAAIBEBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMAAAgEQEGAACQiAADAABIRIABAAAkIsAAAAASEWAAAACJCDAAAIBEBBgAAEAiAgwAACARAQYAAJCIAAMAAEhEgAEAACQiwAAAABIRYAAAAIkIMAAAgEQEGAAAQCICDAAAIBEBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMAAAgEQEGAACQiAADAABIRIABAAAkIsAAAAASEWAAAACJCDAAAIBEBBgAAEAiAgwAACARAQYAAJCIAAMAAEhEgAEAACQiwAAAABIRYAAAAIkIMAAAgEQEGAAAQCICDAAAIBEBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMAAAgEQEGAACQiAADAABIRIABAAAkIsAAAAASEWAAAACJCDAAAIBEBBgAAEAiAgwAACARAQYAAJCIAAMAAEhEgAEAACQiwAAAABIRYAAAAIkIMAAAgEQEGAAAQCICDAAAIBEBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMAAAgEQEGAACQiAADAABIRIABAAAkIsAAAAASEWAAAACJCDAAAIBEBBgAAEAiAoydbKnfHtu2N0RjlsW27Q2xpX57kvO+V1cfdf85b932hnivrj7JeQEAIJXKYi+A0rFl2/bYur0x7p7/Ukxdujo2bNkWn6uuiouP6xbXnNozWlWWR3VV8//IbN62Peq2N8Zd816Kac//97yD+3SLUaf1jHxleRy0D84LAACp+a2WiIio294Qd//15bhx+vNR39D4oXvej6VvrI//9+e/x60X9InRp/WMfGVFs513a31D3D3/5bjp0V2f9yeP/T3Gn98nvnNaz8jnmu+8AABQDAKM2LJte9z915fj+w8v2e0x9Q2N8f2Hl0RZlMXIr/5Ps7wStnnb9rh7/svxg0f2fN4fPLIkyiJi5KlHeSUMAIAWzWfAiK3bG+LG6c/v1bE3TF8aW7c3fvyBe3Pe+oa46dG9O++Njz4fdc10XgAAKBYBdoDbUv/Bq1BN3/63e/UNjfGL+S9/5gtzvFdX/4nPe/f8l1yYAwCAFk2AHeAqyspi6tLVn+gxU5euivKyss903lxFeUx7/pOdd9rS1ZGr8CMLAEDL5bfZA1xlRXls2LLtEz1mw5b6zxxCuSKdFwAAislvswe47Q2N8bnqqk/0mM9V5/b6rYO7U1+k8wIAQDEJsANcQ5bFxcd1+0SPufi47tGYZZ/pvPUNjTG4zyc77+DjugkwAABaNAF2gKvOVcY1px6112/ty1WUx8hTj4rq3Ge7HPzB+dwnPu81p/aMg/O5z3ReAAAoJgFGtKqsiFsv6LNXx0648LhoVdk8PzatchUx/vy9O++t5/eJfDOdFwAAisW/aktUV1XG6NN6RlmUxQ3Tl+7ybX65ivK47YLj4ppTj4p8ZUWznPegqsr4zmk9oyw++He+dnfeW8/vE6NP6xn5XPOcFwAAikWAERER+cqKGPnV/4lv9jsifjH/5Zi6dFVs2FIfn6vOxcXHdY+Rpx4VrSrLmy2+CufNVcTIU4+KK/sfGXfPfymmLV1dOO/g47rFNaf2jHxlufgCAGC/0CICbO7cuTFgwIBd3ve3v/0tTjzxxIiIWLVqVVxzzTUxZ86cqK6ujqFDh8akSZOiquqTXW3vQFVdVRnVVRHXnvmFuP5/vxi5ivKob2iMxiz7zJ/52pODqirjoKqIMQO+EN//316F89Y3NPrMFwAA+5UWEWD9+/ePNWvWNLnt5ptvjieeeCJOOOGEiIhoaGiIc889Nzp27BhPPfVUvP322zFs2LDIsizuvPPOYiy7xfpwbDX3K1578uHYyldWJD03AACk0CICrKqqKmprawtf19fXx/Tp02PUqFFRVlYWERGzZs2K5cuXx+rVq6NLly4REXH77bfH8OHDY/z48dG2bduirB0AAGCHFnlZuenTp8e6deti+PDhhdsWLFgQvXv3LsRXRMTZZ58ddXV1sXjx4iKsEgAAoKkW8QrYR02ePDnOPvvs6Nbtv/+Q79q1a6NTp05Njmvfvn1UVVXF2rVrd/tcdXV1UVdXV/h648aNEfHBq2z19fWfan07HvdpH8++YS6lyVxKj5mUJnMpTeZSmsylNLXEueyLtRY1wMaNGxe33HLLHo9ZtGhR4XNeERFvvPFGPP744/G73/1up2N3vB3xw7Is2+XtO9x22227XMOsWbPioIMO2uPaPs7s2bM/0+PZN8ylNJlL6TGT0mQupclcSpO5lKaWNJfNmzc3+3OWZVmWNfuz7qV169bFunXr9njMoYceGq1atSp8/ZOf/CTuvPPOePPNNyOX++9FG3784x/HH//4x3j++ecLt61fvz46dOgQc+bM2e1VFHf1Cli3bt1i3bp1n/pzY/X19TF79uw466yzmqyR4jKX0mQupcdMSpO5lCZzKU3mUppa4lw2btwYNTU18e677zbbNSWK+gpYTU1N1NTU7PXxWZbFfffdF9/4xjd2Glq/fv1i/PjxsWbNmujcuXNEfPAqVj6fj759++72OfP5fOTz+Z1uz+Vyn/kHozmeg+ZnLqXJXEqPmZQmcylN5lKazKU0taS57It1tqiLcMyZMydWrlwZV1555U73DRw4MHr16hVXXHFFLFmyJP7yl7/E9ddfHyNGjHAFRAAAoCS0qACbPHly9O/fP774xS/udF9FRUXMnDkzWrVqFSeffHJ87Wtfi4suuigmTZpUhJUCAADsrEVdBfHBBx/c4/3du3ePGTNmJFoNAADAJ9OiXgEDAABoyQQYAABAIgIMAAAgEQEGAACQiAADAABIRIABAAAkIsAAAAASEWAAAACJCDAAAIBEBBgAAEAiAgwAACARAQYAAJCIAAMAAEhEgAEAACQiwAAAABIRYAAAAIlUFnsBpSbLsoiI2Lhx46d+jvr6+ti8eXNs3Lgxcrlccy2Nz8hcSpO5lB4zKU3mUprMpTSZS2lqiXPZ0QQ7GqE5CLCP2LRpU0REdOvWrcgrAQAASsGmTZuiXbt2zfJcZVlz5tx+oLGxMf75z39GmzZtoqys7FM9x8aNG6Nbt26xevXqaNu2bTOvkE/LXEqTuZQeMylN5lKazKU0mUtpaolzybIsNm3aFF26dIny8ub59JZXwD6ivLw8unbt2izP1bZt2xbzw3UgMZfSZC6lx0xKk7mUJnMpTeZSmlraXJrrla8dXIQDAAAgEQEGAACQiADbB/L5fIwdOzby+Xyxl8KHmEtpMpfSYyalyVxKk7mUJnMpTebyARfhAAAASMQrYAAAAIkIMAAAgEQEGAAAQCICrJn94he/iMMOOyxatWoVffv2jb/+9a/FXtIBZdy4cVFWVtbkT21tbeH+LMti3Lhx0aVLl6iuro7TTz89XnzxxSKueP80f/78OP/886NLly5RVlYWjzzySJP792YOdXV1MXr06KipqYnWrVvHBRdcEG+88UbC72L/83FzGT58+E775ytf+UqTY8yled12221x4oknRps2beKQQw6Jiy66KF566aUmx9gv6e3NXOyX9H75y1/GscceW/g3pPr16xd//vOfC/fbK+l93Ezsk10TYM3ooYceijFjxsRNN90US5Ysia9+9asxaNCgWLVqVbGXdkA5+uijY82aNYU/y5YtK9z305/+NO6444646667YtGiRVFbWxtnnXVWbNq0qYgr3v+8//770adPn7jrrrt2ef/ezGHMmDHx8MMPx5QpU+Kpp56K9957L84777xoaGhI9W3sdz5uLhER55xzTpP986c//anJ/ebSvObNmxfXXHNNLFy4MGbPnh3bt2+PgQMHxvvvv184xn5Jb2/mEmG/pNa1a9eYMGFCPPvss/Hss8/GGWecERdeeGEhsuyV9D5uJhH2yS5lNJsvf/nL2VVXXdXkti984QvZj370oyKt6MAzduzYrE+fPru8r7GxMautrc0mTJhQuG3r1q1Zu3btsl/96leJVnjgiYjs4YcfLny9N3PYsGFDlsvlsilTphSOefPNN7Py8vLsscceS7b2/dlH55JlWTZs2LDswgsv3O1jzGXfe+utt7KIyObNm5dlmf1SKj46lyyzX0pF+/bts3vuucdeKSE7ZpJl9snueAWsmWzbti0WL14cAwcObHL7wIED4+mnny7Sqg5Mr7zySnTp0iUOO+ywuPTSS2PFihUREbFy5cpYu3Ztkxnl8/k47bTTzCihvZnD4sWLo76+vskxXbp0id69e5vVPjZ37tw45JBD4qijjooRI0bEW2+9VbjPXPa9d999NyIiOnToEBH2S6n46Fx2sF+Kp6GhIaZMmRLvv/9+9OvXz14pAR+dyQ72yc4qi72A/cW6deuioaEhOnXq1OT2Tp06xdq1a4u0qgPPSSedFL/5zW/iqKOOin/961/xf//3f9G/f/948cUXC3PY1Yxef/31Yiz3gLQ3c1i7dm1UVVVF+/btdzrGftp3Bg0aFJdcckn06NEjVq5cGTfffHOcccYZsXjx4sjn8+ayj2VZFtdee22ccsop0bt374iwX0rBruYSYb8Uy7Jly6Jfv36xdevWOPjgg+Phhx+OXr16FX5Zt1fS291MIuyT3RFgzaysrKzJ11mW7XQb+86gQYMKfz/mmGOiX79+ccQRR8QDDzxQ+NCnGZWGTzMHs9q3hgwZUvh7796944QTTogePXrEzJkzY/Dgwbt9nLk0j1GjRsULL7wQTz311E732S/Fs7u52C/F0bNnz1i6dGls2LAhpk6dGsOGDYt58+YV7rdX0tvdTHr16mWf7Ia3IDaTmpqaqKio2KnW33rrrZ3+bwzptG7dOo455ph45ZVXCldDNKPi2ps51NbWxrZt22L9+vW7PYZ9r3PnztGjR4945ZVXIsJc9qXRo0fH9OnT48knn4yuXbsWbrdfimt3c9kV+yWNqqqqOPLII+OEE06I2267Lfr06RM/+9nP7JUi2t1MdsU++YAAayZVVVXRt2/fmD17dpPbZ8+eHf379y/Sqqirq4t//OMf0blz5zjssMOitra2yYy2bdsW8+bNM6OE9mYOffv2jVwu1+SYNWvWxN///nezSujtt9+O1atXR+fOnSPCXPaFLMti1KhRMW3atJgzZ04cdthhTe63X4rj4+ayK/ZLcWRZFnV1dfZKCdkxk12xT/4j+WU/9mNTpkzJcrlcNnny5Gz58uXZmDFjstatW2evvfZasZd2wLjuuuuyuXPnZitWrMgWLlyYnXfeeVmbNm0KM5gwYULWrl27bNq0admyZcuyyy67LOvcuXO2cePGIq98/7Jp06ZsyZIl2ZIlS7KIyO64445syZIl2euvv55l2d7N4aqrrsq6du2aPfHEE9lzzz2XnXHGGVmfPn2y7du3F+vbavH2NJdNmzZl1113Xfb0009nK1euzJ588smsX79+2ec//3lz2YeuvvrqrF27dtncuXOzNWvWFP5s3ry5cIz9kt7HzcV+KY4bbrghmz9/frZy5crshRdeyG688casvLw8mzVrVpZl9kox7Gkm9snuCbBmdvfdd2c9evTIqqqqsuOPP77JJWvZ94YMGZJ17tw5y+VyWZcuXbLBgwdnL774YuH+xsbGbOzYsVltbW2Wz+ezU089NVu2bFkRV7x/evLJJ7OI2OnPsGHDsizbuzls2bIlGzVqVNahQ4esuro6O++887JVq1YV4bvZf+xpLps3b84GDhyYdezYMcvlcln37t2zYcOG7fTf3Fya167mERHZfffdVzjGfknv4+ZivxTHN7/5zcLvWB07dszOPPPMQnxlmb1SDHuaiX2ye2VZlmXpXm8DAAA4cPkMGAAAQCICDAAAIBEBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMgAPS8OHDo6ysLMrKyqKysjK6d+8eV199daxfv77JcVu2bIn27dtHhw4dYsuWLUVaLQD7CwEGwAHrnHPOiTVr1sRrr70W99xzTzz66KMxcuTIJsdMnTo1evfuHb169Ypp06YVaaUA7C8qi70AACiWfD4ftbW1ERHRtWvXGDJkSNx///1Njpk8eXJcfvnlkWVZTJ48Ob7+9a8XYaUA7C8EGABExIoVK+Kxxx6LXC5XuO3VV1+NBQsWxLRp0yLLshgzZkysWLEiDj/88CKuFICWzFsQAThgzZgxIw4++OCorq6OI444IpYvXx4//OEPC/ffe++9MWjQoMJnwM4555y49957i7hiAFo6AQbAAWvAgAGxdOnSeOaZZ2L06NFx9tlnx+jRoyMioqGhIR544IG4/PLLC8dffvnl8cADD0RDQ0OxlgxACyfAADhgtW7dOo488sg49thj4+c//3nU1dXFLbfcEhERjz/+eLz55psxZMiQqKysjMrKyrj00kvjjTfeiFmzZhV55QC0VGVZlmXFXgQApDZ8+PDYsGFDPPLII4Xb5s6dG4MGDYpXX301Ro8eHVVVVXHTTTc1edyECRNi69at8Yc//CHxigHYH7gIBwD8x+mnnx5HH310jB8/Ph599NGYPn169O7du8kxw4YNi3PPPTf+/e9/R8eOHYu0UgBaKm9BBIAPufbaa+PXv/511NfXx5lnnrnT/QMGDIg2bdrEb3/72yKsDoCWzlsQAQAAEvEKGAAAQCICDAAAIBEBBgAAkIgAAwAASESAAQAAJCLAAAAAEhFgAAAAiQgwAACARAQYAABAIgIMAAAgEQEGAACQiAADAABI5P8DbMRCdG0UAc8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x1000 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "\n",
     "## 3.3 Positions\n",
@@ -1016,7 +1624,7 @@
     "# Add labels and title\n",
     "plt.xlabel('RA')\n",
     "plt.ylabel('DEC')\n",
-    "title = \"\"\"RA, DEC positions of %s Observations of Different Science Program Targets on %s\"\"\" %(instrument, day_obs)\n",
+    "title = \"\"\"RA, DEC positions of %s Observations of Different Science Program Targets\\n between %s and %s (inclusive)\"\"\" %(instrument, day_obs_start, day_obs_end)\n",
     "plt.title(title)\n",
     "plt.grid(True)"
    ]
@@ -1031,10 +1639,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "c34cf1ba-4e0d-429f-8d9b-52fa29f08658",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.371008Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.370844Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.495270Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.494861Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.370994Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA4cAAANnCAYAAACCqS0UAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACT4ElEQVR4nOzdd3gUVcPG4WdJz4ZAKCHUhJqA0lQQQSUBQlcQFClSRZAqAq8dAUVEQAV9RUQQRLqKoEivghRREemCCEhHSCghhJTz/cG3+7LZ3SQLiQH93deVC/bMmZkzZ2fP7rMzO2MxxhgBAAAAAP7V8uR2AwAAAAAAuY9wCAAAAAAgHAIAAAAACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhsshisWT6N2zYsBxb/9q1a2WxWLR27Vp72eLFi92u02KxqG/fvjnehi5duigiIsKj5Rw/flzDhg3TL7/8kq3tu9XNnTtXd9xxhwICAmSxWG6Z7d+2bZvq1q2rfPnyyWKxaNy4cW7rZmW/Sk5O1kcffaQaNWqoQIECCgwMVHh4uFq0aKGvvvrKoe6ff/6p3r17q0KFCgoICFCBAgVUuXJlPfXUU/rzzz916NChLL32LBaLDh06JEk6ePCg+vbta19mYGCg7rjjDr3yyis6duzYzXbXDbtV2+VKQkKCRo0aperVqysoKEhWq1XVqlXTyJEjlZCQ4FQ/J8abW8nu3bs1bNgw+z52vRsZA29Fno4Dtj8vLy+FhISoatWq6tmzpzZv3uxU3/Y6njZtmkO5uzHx/fffV7ly5eTr6yuLxaL4+Pjs29BsdCPvZXv27FHHjh1VpkwZ+fv7q1ChQrrrrrvUt29fXbhwwaP1Dxs2TBaLxcNW33qmTZvmsE95e3urRIkS6tq16y03Nuam9P3k7u9WHI9mzZqV4Zhyq/HO7Qbg9rBp0yaX5SkpKerUqZOOHTumpk2b5tj677rrLm3atEmVKlWyly1evFgffPBBjobSzAwZMkTPPPOMR/McP35cw4cPV0REhKpVq5YzDbvFnDlzRh07dlTjxo01YcIE+fn5qUKFCrndLElSt27dlJCQoDlz5igkJOSm31g6duyo+fPna8CAARo+fLj8/Px08OBBLV26VMuWLdMjjzwiSTp69Kjuuusu5c+fX4MGDVJkZKTOnz+v3bt3a968eTp48KBq1arl9Nrr3bu3zp8/r5kzZzqUFy1aVIsWLVLbtm1VqFAh9e3bV9WrV5fFYtGOHTv0ySef6Ntvv9W2bdtuavtuxK3aLldOnTqlBg0a6Pfff1f//v01evRoSdLq1as1YsQIzZ49WytXrlSRIkVyuaV/n927d2v48OGKjo52en3cyBh4K/J0HHj00Uc1aNAgGWN04cIF7dy5U9OnT9ekSZPUv39/jR8/3l63aNGi2rRpk8qWLWsvczcm/vLLL+rfv7+6d++uzp07y9vbW3nz5s2pzb4pnr6Xbdu2TXXq1FHFihX16quvKiIiQn/99Ze2b9+uOXPmaPDgwQoODs7y+rt3767GjRvfxBbcWqZOnaqoqCglJibqu+++05tvvql169Zpx44dslqtud28XNesWTOn98P77rvP/lq08fPz+7ublqlZs2Zp586dGjBgQG43JWsMcBP69etnJJmPPvrob193nz59jLtdWJLp06dPtq5vzZo1RpJZs2bNTS1n69atRpKZOnVqtrTrdrBhwwYjycydOzfblpmQkJAty/H29ja9evXKUt3M9quDBw8aSebVV191OT01NdX+/1dffdVIMgcPHsy07vXq1q1r7rjjDpfrtlqtpnr16iY+Pt5pelpamvnyyy/dtj2n3Krtcqdhw4bG29vbrF+/3mna+vXrjbe3t2nUqJFDeU6MNzfi8uXLJi0tLduX+/nnn2fL2Hcry45xICUlxXTr1s1IMhMmTMhwGe7GxBkzZhhJZsuWLVlvfCaya6xMz9P3sk6dOhmr1WouXLjgcnpO7Lu3g6lTpxpJZuvWrQ7lQ4YMMZLMjBkz3M6bU89tbq8rq7Jz7E1JSTFXrlzJlmWl16xZMxMeHp4jy84JhEPcsOnTpxtJ5sknn3SalpSUZF5//XUTGRlpfH19TaFChUyXLl3M6dOnHeqFh4ebZs2amSVLlpjq1asbf39/ExkZaaZMmeJQL30w69y5s5Hk9PfHH38YY/43YEyfPt1ERUWZgIAAU6VKFfPNN99kadv27NljGjVqZAICAkzBggVNz549zddff+30Aalz585OL/h58+aZmjVrmuDgYBMQEGBKly5tunbt6rAd6f+GDh1qjLn2Zvv444+b8PBw4+/vb8LDw03btm3NoUOHHNZhezNZvXq1efrpp03BggVNgQIFzCOPPGKOHTvmtD0zZ840tWrVMlar1VitVlO1alUzefJkhzorVqww9erVM3nz5jUBAQGmdu3aZuXKlQ51Tp8+bZ566ilTokQJ+/Nau3Zts2LFCrd96eq5qlu3rn36woULTa1atUxAQIAJCgoyDRo0MBs3bnRYxtChQ40k89NPP5nWrVub/Pnzm7CwMLfrNMaYHTt2mIcfftjkz5/f+Pn5mapVq5pp06Y59WH6v4xk9kZk+7D04YcfZrgcY659uZEnTx5z6dKlTOtez1047Nu3r5FkNm3alOVlTZkyxVSpUsX4+fmZkJAQ07JlS7N7926HOp07dzZWq9Xs2bPHNGzY0AQGBpqwsDDz5ptvGmOM2bRpk6lTp44JDAw05cuXd+jjG2nX8uXLzcMPP2yKFy9u/Pz8TNmyZU2PHj3MmTNnHOrZ9ont27ebRx991AQHB5uQkBDz7LPPmuTkZLN3717TqFEjExQUZMLDw81bb72V6bptz1/Pnj3d1unRo4eRZH788Ud7mW2/mDhxoilfvrzx9fU1FStWNLNnz3aYNyEhwQwaNMhERETY+/zuu+82s2bNcmrHQw89ZEJCQoyfn5+pVq2aU4iw7b/Lli0zXbt2NYUKFTKSzOzZs40kp9euMcZMmDDB3me29WQ23rh7ndgCgasxMDEx0bzwwgsmIiLC+Pj4mGLFipnevXubuLg4h3pZHf+z2m+u/N3jwOXLl02hQoVM6dKl7WV//PGHU5+5GhPr1q3rVN65c2f7crIyRmc0VqalpZkPPvjAVK1a1fj7+5v8+fOb1q1bm99//91hGbYx5ocffjD333+//X3szTfftH9pldl7mSvNmjUzRYsWzXIIXLJkialXr579vTQqKsqMHDnSaVvTmzNnjqlVq5YJDAw0VqvVNGzY0Pz8888OdWzj2v79+02TJk2M1Wo1JUqUMAMHDnQKCFeuXDHDhw83UVFRxs/PzxQoUMBER0eb77//3l4nq33rirtw+O233xpJ5o033nBo86+//mpiY2NNUFCQqVWrljHGmLNnz5pevXqZYsWKGR8fH1O6dGnz0ksvOW1LXFyc6datmwkJCTFWq9U0bdrU/P77707PXUb7kaefU1atWmW6d+9uChQoYPLmzWs6duxoLl26ZE6cOGEee+wxky9fPhMWFmYGDRpkrl69mml/XS/9a/H06dOmV69epmLFisZqtZrChQubmJgY89133znMZ3tNvvXWW+b11183ERERxsvLyyxZssQYY8yCBQtM5cqVja+vryldurQZN26cy/0tK8+7q9f19cuZMGGCqVKlirFarSYoKMhERkaaF1980aN+yG6EQ9yQn3/+2QQEBJgaNWo4DT6pqammcePGxmq1muHDh5sVK1aYyZMnm+LFi5tKlSqZy5cv2+uGh4ebEiVKmEqVKpnp06ebZcuWmccee8xIMuvWrbPXSx8ODxw4YB599FH7h07bn60tkkxERISpWbOmmTdvnlm8eLGJjo423t7emQ7WJ0+eNKGhoaZ48eJm6tSpZvHixaZDhw6mVKlSmYbDjRs3GovFYtq2bWsWL15sVq9ebaZOnWo6duxojDHm/Pnz9gHzlVdesbf7zz//NMZc+4b+1VdfNV999ZVZt26dmTNnjqlbt64pXLiww4dj2zLKlClj+vXrZ5YtW2YmT55sQkJCTExMjMP22L59bNWqlfn888/N8uXLzTvvvGOGDBlir/PZZ58Zi8ViWrZsaebPn2+++eYb07x5c+Pl5eXw4aNRo0amcOHCZtKkSWbt2rVmwYIF5tVXXzVz5sxx258HDhwwH3zwgZFkRo4caTZt2mR27dpljLkWWiWZhg0bmgULFpi5c+eau+++2/j6+jocubENyuHh4eb55583K1asMAsWLHC7zr1795q8efOasmXLmunTp5tvv/3WtGvXzv5mYMy1N5FNmzYZSebRRx+1PxcZySwcXrp0yf4m+tFHH9m/rHDFdoSgYcOGZunSpeb8+fMZrtvGXTisUKGCKVKkSJaWYYwxI0eONJJMu3btzLfffmumT59uypQpY/Lly2d+++03e73OnTvbw8748ePNihUrTNeuXY0k8+KLL5oKFSqYKVOmmGXLlpnmzZs7BSdP2/Xhhx+aN99803z99ddm3bp15tNPPzVVq1Y1kZGRDh8cbPtEZGSkef31182KFSvMc889ZySZvn37mqioKPPee+85tDezI5S2PrF9QHBl8eLFRpI9HBtzbb8oWbKkqVSpkpk9e7b5+uuvTePGjY0k8/nnn9vr9ezZ0wQGBpp33nnHrFmzxixatMiMGjXKvP/++/Y6q1evNr6+vuaBBx4wc+fONUuXLjVdunRxOkJjGwOKFy9uevToYZYsWWK++OILc+XKFRMaGmo6dOjg1PaaNWuau+66y/44K+PN6dOn7f3ywQcf2F8nti/60o+BaWlpplGjRsbb29sMGTLELF++3IwdO9Z+9Pj694usjv9Z6TdXcmscaNu2rZFkH9fTh0N3Y+KuXbvMK6+8Yq+7adMmc+DAAWNM1sfojMbKp556yvj4+JhBgwaZpUuXmlmzZpmoqChTpEgRc/LkSfsy6tatawoWLGjKly9vJk6caFasWGF69+5tJJlPP/3UGJP5e5krI0aMsI85a9eudfgskN7kyZONxWIx0dHRZtasWWblypVmwoQJpnfv3k7ber033njDWCwW061bN7No0SIzf/58c9999xmr1Wp/3zHGcVwbO3asWblypXn11VeNxWIxw4cPt9dLTk42MTExxtvb2wwePNgsXrzYfP311+all15y+PInq33rirtwOH78eCPJTJo0yd5mHx8fExERYd58802zatUqs2zZMpOYmGgPF2PHjjXLly83Q4YMMd7e3qZp06b25aWmppr777/f+Pv7m1GjRpnly5eb4cOHm/Lly7sNh672I08/p5QuXdoMGjTILF++3Lz11lvGy8vLtGvXztx1111mxIgRZsWKFeb55583kszbb7+dYV+ll/61uHfvXtOrVy8zZ84cs3btWrNo0SLz5JNPmjx58jh8drO9JosXL25iYmLMF198YZYvX27++OMPs2TJEpMnTx4THR1tvvrqK/P555+be++910RERDjtb1l53nft2mXq1KljwsLCHD6vGmPsX+b169fPLF++3KxcudJMnDjR9O/f36N+yG6EQ3jszJkzJjw83BQuXNgcOXLEabptZ0//Qcz2rfz1p9vYvnk6fPiwvSwxMdEUKFDA4dt7V6d0ZnZaaZEiRRxOXzl58qTJkyePw4c6V55//nljsVjML7/84lAeGxubaTgcO3askeTy9DkbT07FSUlJMZcuXTJWq9WMHz/eXm4bdK9/ozTGmNGjRxtJ5sSJE8aYa6f0eXl5ufygaJOQkGAKFChgHnroIYfy1NRUU7VqVVOzZk17WVBQkBkwYECm7U7P9vxd/0E5NTXVFCtWzFSuXNnhFMqLFy+a0NBQU7t2bXuZ7Y3K3ema6bVt29b4+fk57Z9NmjQxgYGBDs9PZh/0rpeVut9++639KI4kU7BgQfPYY4+Zr7/+2qFeWlqa6dmzp8mTJ4+RZCwWi6lYsaJ59tlnMwyV7sKhv7+//VvkzMTFxZmAgACHDw7GGHPkyBHj5+dn2rdvby+zHeW4/vWcnJxsChcubCQ5fCN/9uxZ4+XlZQYOHHhD7UovLS3NJCcnm8OHDxtJZuHChfZptn0i/YeJatWqGUlm/vz5Tu1t1apVhut7+umnjSSzd+9et3X27NljJDmcgijJBAQEOHwITElJMVFRUaZcuXL2sjvvvNO0bNkywzZERUWZ6tWrm+TkZIfy5s2bm6JFi9pfK7YxoFOnTk7LGDhwoAkICHDYz3fv3m0kZRio3I03GZ1Wmn4MXLp0qZFkRo8e7VBv7ty5Dh90jcn6+J+VfnMlt8YB2wdd26mh6cOhMa7HRGNcBwVPxmh3Y6UtAKd/vfz5558mICDAPPfcc/Yy25GO9Ke2VqpUyeGUak9PK71y5Ypp2bKlfWz08vIy1atXNy+//LLDWUUXL140wcHB5v7778/wKGP6cHjkyBHj7e1t+vXr51Dv4sWLJiwszLRp08ZeZhvX5s2b51C3adOmJjIy0v7YdobUxx9/7LYdnvStK7bnfPPmzSY5OdlcvHjRLFq0yBQuXNjkzZvXPq7Y2vzJJ584zD9x4kSX2/LWW28ZSWb58uXGmP8diUx/Zsubb77pNhxm5T03s88p6Z8P2z7wzjvvOJRXq1bN4currMjstZiSkmKSk5NN/fr1zSOPPGIvt70my5Yt63S0skaNGqZkyZImKSnJXnbx4kVTsGBBh/3Nk+fd3Wmlffv2Nfnz58/y9v5duFopPJKamqq2bdvq6NGjmjt3rkqWLOlUZ9GiRcqfP78eeughpaSk2P+qVaumsLAwh6t9SlK1atVUqlQp+2N/f39VqFBBhw8fvqm2xsTEOPyQv0iRIgoNDc10uWvWrNEdd9yhqlWrOpS3b98+03XWqFFDktSmTRvNmzfP4yuNXbp0Sc8//7zKlSsnb29veXt7KygoSAkJCdqzZ49T/YcfftjhcZUqVSTJvo0rVqxQamqq+vTp43adGzdu1Llz59S5c2eH5ystLU2NGzfW1q1b7VdorFmzpqZNm6YRI0Zo8+bNSk5O9mj7rrdv3z4dP35cHTt2VJ48/xuKgoKC1Lp1a23evFmXL192mKd169ZZWvbq1atVv359p/2zS5cuunz5stsLLGWHpk2b6siRI/rqq680ePBg3XHHHVqwYIEefvhhhytaWiwWTZw4UQcPHtSECRPUtWtXJScn691339Udd9yhdevW5VgbN23apMTERHXp0sWhvGTJkqpXr55WrVrlUG6xWBwuOOXt7a1y5cqpaNGiql69ur28QIECWXqNZeT06dN6+umnVbJkSXl7e8vHx0fh4eGS5PI10Lx5c4fHFStWlMViUZMmTZzae7NjiiQZYyTJ6SqJ9evXd7hIjZeXlx5//HEdOHBAR48elXTt9bNkyRK98MILWrt2rRITEx2WceDAAe3du1cdOnSQJIfXY9OmTXXixAnt27fPYR5Xr4lu3bopMTFRc+fOtZdNnTpVfn5+DuOYp+NNVqxevVqSnPatxx57TFar1Wnfysr4n1m/ZdSW3BgHbPtIdvFkjLZJv18sWrRIFotFTzzxhMMywsLCVLVqVaf35bCwMNWsWdOhrEqVKjf1GvLz89NXX32l3bt3691331Xbtm115swZvfHGG6pYsaJ93964caMuXLig3r17e3Q10mXLltkvknf9Nvr7+6tu3bpO22ixWPTQQw9luI1LliyRv7+/unXr5na9nvatO7Vq1ZKPj4/y5s2r5s2bKywsTEuWLHG6+FX653b16tWyWq169NFHHcptr0Hba872ntKmTRuHeu3atXPbJlfji6fjhqsxWrp2gZn05dkxRk+cOFF33XWX/P397e8hq1atcvsZysfHx/44ISFBP/74o1q2bClfX197eVBQkNO+kh3Pe82aNRUfH6927dpp4cKF+uuvv258w7MRVyuFR5577jmtWrVKY8eOVUxMjMs6p06dUnx8vMML63rpd/6CBQs61fHz88vyBwB3bnS5Z8+eVenSpZ3Kw8LCMl3ngw8+qAULFui9995Tp06dlJSUpDvuuEMvv/xyhgOwTfv27bVq1SoNGTJENWrUUHBwsP2Duat2p99G21W6bHXPnDkjSSpRooTbdZ46dUqSnN5Yrnfu3DlZrVbNnTtXI0aM0OTJkzVkyBAFBQXpkUce0ejRo7PUP9c7e/aspGtX8kuvWLFiSktLU1xcnAIDA+3lruq6W7a75V6/7pwSEBCgli1bqmXLlpKkI0eOqEmTJvrggw/Uq1cv3XHHHfa64eHh6tWrl/3xvHnz1K5dO/3nP//RDz/8kOV1lipVSn/88UeW6mbW9ytWrHAoCwwMlL+/v0OZr6+vChQo4DS/r6+vrly5ckPtSktLU8OGDXX8+HENGTJElStXltVqVVpammrVquXyNZC+Db6+vm7bm9ml8m0h5Y8//lBkZKTLOrbbOaQPHK72f1vZ2bNnVaJECb333nsqUaKE5s6dq7feekv+/v5q1KiRxowZo/Lly9tfi4MHD9bgwYNdrj/9+OnqObzjjjtUo0YNTZ06VT169FBqaqpmzJihFi1aOPSXp+NNVpw9e1be3t4qXLiwQ7nFYlFYWJjTay8r43Rm/ZZRW3JjHLB9wLWt52Z5MkbbpN/uU6dOyRjj9iq7ZcqUcXicU+/L0rUQYAsIxhiNGzdOAwcO1JAhQzRv3rwsvW+5Yusn25e06V3/JaTkelzz8/NzGL/OnDmjYsWKOc2bfr2e9K0706dPV8WKFeXt7a0iRYq43HcDAwOdruh69uxZhYWFOQXp0NBQeXt72/dz22sz/ZiZ0ZWXXbXB03HD1Rjtrvz6vr8R77zzjgYNGqSnn35ar7/+ugoVKiQvLy8NGTLEZThMv31xcXFun8v0ZdnxvHfs2FEpKSn6+OOP1bp1a6WlpalGjRoaMWKEYmNjM50/pxAOkWWzZ8/WO++8o8cff9zhssHpFSpUSAULFtTSpUtdTr9VL8ttU7BgQZ08edKp3FWZKy1atFCLFi2UlJSkzZs3680331T79u0VERGh++67z+1858+f16JFizR06FC98MIL9vKkpCSdO3fO8w2R7B/Qjh496vIor3Tt+ZKu3VurVq1aLuvYBr9ChQpp3LhxGjdunI4cOaKvv/5aL7zwgk6fPu32+XbH9uHjxIkTTtOOHz+uPHnyKCQkxKE8q98iFyxY0O1ybdvxdypVqpR69OihAQMGaNeuXQ7hML02bdrozTff1M6dOz1aR6NGjfT+++9r8+bNbp9Hm8z6Pjv7x5N27dy5U9u3b9e0adPUuXNne/mBAweyrT0ZiY2N1UsvvaQFCxa4vUT+ggUL7HWvl9GYYetvq9Wq4cOHa/jw4Tp16pT9aNhDDz2kvXv32vv9xRdfVKtWrVyuP31odfea6Nq1q3r37q09e/bo4MGDOnHihLp27WqfnhPjjW1bU1JSdObMGYeAaIzRyZMn3X5wz0hm/ZZRW/7ucSAxMVErV65U2bJlPQ437ngyRtuk3y8KFSoki8Wi9evXu7zUf25d/t9isejZZ5/Va6+9Zh/zrn/f8oStn7744gv72QY3q3DhwtqwYYPS0tLcBsTs6tuKFSvqnnvuybCOq9d7wYIFtWXLFhljHKafPn1aKSkp9n6xvTbPnTvnEMwy+myTfn05NW5klxkzZig6OloffvihQ/nFixdd1k+/fSEhIbJYLPYvGq6Xvp+y63nv2rWrunbtqoSEBH333XcaOnSomjdvrt9++y3b9mNPcVopsuTXX39V9+7ddeedd2rKlCkZ1m3evLnOnj2r1NRU3XPPPU5/7r6R91T6o2TZJSYmRrt27dL27dsdymfNmuXRcvz8/FS3bl299dZbkmS/j5u7dlssFhljnAaUyZMnKzU11aN12zRs2FBeXl5OA+X16tSpo/z582v37t0un6977rnH5VHgUqVKqW/fvoqNjdXPP//scdsiIyNVvHhxzZo1y+E0rISEBH355Ze67777HI4aeqJ+/fpavXq1/UOgzfTp0xUYGJhpSLlRFy9e1KVLl1xOs31raTua4OpDq3TtlJ0///zT46MOzz77rKxWq/0+iOkZY/TVV19JunZvqICAAM2YMcOhztGjR+2n4mUXT9ple6NO/xr46KOPsq09GbnnnnvUsGFDTZkyRd9//73T9A0bNuiTTz5R48aNdffddztMW7VqlcMHitTUVM2dO9dtSChSpIi6dOmidu3aad++fbp8+bIiIyNVvnx5bd++3e1rMatfrrVr107+/v6aNm2apk2bpuLFi6thw4b26Z6MN56MtbZ9J/2+9eWXXyohIeGm9y1X/ZZRW/7OcSA1NVV9+/bV2bNn9fzzz2fbcm90jL5e8+bNZYzRsWPHXM5fuXJlj9vl6XuwuzHv+PHjunDhgn3Mq127tvLly6eJEyd6dIpuo0aN5O3trd9//91tP3mqSZMmunLliqZNm+a2Tk70rSfq16+vS5cu2b+4spk+fbp9uiTVrVtXkhxON5ekOXPmZHldOfE5JTtZLBantv36669ZPoXcarXqnnvu0YIFC3T16lV7+aVLl7Ro0SKHup4871k56m61WtWkSRO9/PLLunr1qnbt2pWlNucEjhwiU3FxcWrZsqWSkpL0/PPPa8eOHS7rFS5cWGXLllXbtm01c+ZMNW3aVM8884xq1qwpHx8fHT16VGvWrFGLFi3sNwK/GbYX3ltvvaUmTZrIy8tLVapUyfRNMjMDBgzQJ598ombNmmnEiBEqUqSIZs6cmeE31Davvvqqjh49qvr166tEiRKKj4/X+PHj5ePjYx+Yy5Ytq4CAAM2cOVMVK1ZUUFCQihUrpmLFiunBBx/UmDFjVKhQIUVERGjdunWaMmWK8ufPf0PbEhERoZdeekmvv/66EhMT1a5dO+XLl0+7d+/WX3/9peHDhysoKEjvv/++OnfurHPnzunRRx9VaGiozpw5o+3bt+vMmTP68MMPdf78ecXExKh9+/aKiopS3rx5tXXrVi1dutTtUY6M5MmTR6NHj1aHDh3UvHlz9ezZU0lJSRozZozi4+M1atSoG9pmSRo6dKgWLVqkmJgYvfrqqypQoIBmzpypb7/9VqNHj1a+fPlueNm///67vvjiC6fySpUq6fLly2rUqJHatm2runXrqmjRooqLi9O3336rSZMmKTo6WrVr15YkvfHGG/r+++/1+OOPq1q1agoICNAff/yh//73vzp79qzGjBnjUbtKly6tOXPm2Jdnu9m8dO0m5p988omMMXrkkUeUP39+DRkyRC+99JI6deqkdu3a6ezZsxo+fLj8/f01dOjQG+6fm2lXVFSUypYtqxdeeEHGGBUoUEDffPON02muOWn69Olq0KCBGjZsqP79+9s/WK1evVrjx49XVFSUyw+KhQoVUr169TRkyBBZrVZNmDBBe/fudfjgde+996p58+aqUqWKQkJCtGfPHn322WcOX4R89NFHatKkiRo1aqQuXbqoePHiOnfunPbs2aOff/5Zn3/+eZa2I3/+/HrkkUc0bdo0xcfHa/DgwQ5HPoKDg7M83tx5552SpEmTJilv3rzy9/dX6dKlXZ56GBsbq0aNGun555/XhQsXVKdOHf36668aOnSoqlevro4dO2ap/dfLSr+5kpPjwKlTp7R582YZY3Tx4kXt3LlT06dP1/bt2/Xss8/qqaeeuuFlp5fVMTojderUUY8ePdS1a1f9+OOPevDBB2W1WnXixAlt2LBBlStXdji9PSsyei9zpUePHoqPj1fr1q115513ysvLS3v37tW7776rPHny2AN1UFCQ3n77bXXv3l0NGjTQU089pSJFiujAgQPavn27/vvf/7pcfkREhF577TW9/PLLOnjwoBo3bqyQkBCdOnVKP/zwg/0ItCfatWunqVOn6umnn9a+ffsUExOjtLQ0bdmyRRUrVlTbtm1zpG890alTJ33wwQfq3LmzDh06pMqVK2vDhg0aOXKkmjZtqgYNGkiSGjdurDp16mjQoEG6cOGC7r77bm3atMkeIjM6ddbGk3EjNzRv3lyvv/66hg4dqrp162rfvn167bXXVLp0aaWkpGRpGa+99pqaNWumRo0a6ZlnnlFqaqrGjBmjoKAgh6OjnjzvlStX1vz58/Xhhx/q7rvvVp48eXTPPffoqaeeUkBAgOrUqaOiRYvq5MmTevPNN5UvX74bOssi2/yNF7/Bbcrd/YzS/11/P6bk5GQzduxY+71fgoKCTFRUlOnZs6fZv3+/vZ7tPlfp2e75lL4N118tLykpyXTv3t0ULlzYWCwWIznf5zC98PBwh3a6s3v3bhMbG2v8/f1NgQIFzJNPPmkWLlyY6dVKFy1aZJo0aWKKFy9ufH19TWhoqGnatKnTDbVnz55toqKijI+Pj8NVwo4ePWpat25tQkJCTN68eU3jxo3Nzp07ndrt7tLXrvrJmGtXXKtRo4b9uahevbrTFebWrVtnmjVrZgoUKGB8fHxM8eLFTbNmzexX07ty5Yp5+umnTZUqVez3nYqMjDRDhw7N9Oa47q7MZ8y1+wnde++9xt/f31itVlO/fn2H+0cZ878rp6W/111GduzYYR566CGTL18+4+vra6pWreryqnru9hVXMtr/hw4dauLi4syIESNMvXr17PuA1Wo11apVMyNGjHC4dPvmzZtNnz59TNWqVU2BAgWMl5eXKVy4sGncuLFZvHix2za4u1qpze+//2569+5typUrZ/z8/ExAQICpVKmSGThwoNNVUCdPnmyqVKlifH19Tb58+UyLFi0cLvduzP/urZXVdrh7TWe1XbbXXt68eU1ISIh57LHHzJEjR9xeTS/9PuFpe125dOmSGTlypKlWrZoJDAw0gYGBpkqVKmbEiBEu70tp24cmTJhgypYta3x8fExUVJSZOXOmQ70XXnjB3HPPPfb7F5YpU8Y8++yz5q+//nKot337dtOmTRsTGhpqfHx8TFhYmKlXr56ZOHGivY67MeB6y5cvt++f19+exCar440xxowbN86ULl3aeHl5OVyh0t19Dp9//nkTHh5ufHx8TNGiRU2vXr3c3ucwvfTjf1b7zZWcHgfy5MljgoODTeXKlU2PHj1c3gbjZq9WapPZGG1M5mPlJ598Yu69915jtVpNQECAKVu2rOnUqZPD7WfcvVZcPdfu3stcWbZsmenWrZupVKmSyZcvn/H29jZFixY1rVq1ctlvixcvNnXr1jVWq9UEBgaaSpUqOdyv1N19DhcsWGBiYmJMcHCw8fPzM+Hh4ebRRx91uOWHu3HC1TITExPNq6++ar+HacGCBU29evWc7seblb51JSuv5YzabMy1K0U//fTTpmjRosbb29uEh4ebF1980elWY+fOnTNdu3Y1+fPnN4GBgSY2NtZs3rzZSHK40mhG+9HNfk7xdOzOSPrXbVJSkhk8eLApXry48ff3N3fddZdZsGCB075re02OGTPG5XK/+uor+30OS5UqZUaNGmX69+9vQkJCnOpm5Xk/d+6cefTRR03+/Pntn1eNMebTTz81MTExpkiRIsbX19cUK1bMtGnTxvz6668e9UN2sxiTzZfVAgAAAHDLmzVrljp06KDvv//efmYLHCUnJ6tatWoqXry4li9fntvNyXGcVgoAAAD8w82ePVvHjh1T5cqVlSdPHm3evFljxozRgw8+SDC8zpNPPqnY2Fj7qZ4TJ07Unj17NH78+Nxu2t+CcAgAAAD8w+XNm1dz5szRiBEjlJCQoKJFi6pLly4aMWJEbjftlnLx4kUNHjxYZ86ckY+Pj+666y4tXrzY/vvNfzpOKwUAAAAAcCsLAAAAAADhEAAAAAAgwiGAf6m1a9fKYrG4vGfhjdq9e7eGDRumQ4cOZdsybyWpqal655131LhxY5UoUUKBgYGqWLGiXnjhBcXHx7uc5/3331dUVJT8/PxUunRpDR8+XMnJyQ515s+fr3bt2qlcuXIKCAhQRESEOnTooP3792fYnsTERFWoUEEWi0Vjx451mv7KK6+oefPmKl68uCwWi7p06eJ2WQcPHlSrVq2UP39+BQUFKTY2Vj///LNDnRMnTuiVV17Rfffdp0KFCik4OFh33323Jk2alOkNoCdPniyLxaKgoKAM6+WGiIiIDPtG8nzbL126pAEDBqhYsWLy9/dXtWrVnG62fSP7k83u3bvl5+cni8WiH3/80WHa0aNHNWDAANWtW1f58+eXxWLJ8CbmK1eutN8zsVChQurSpYtOnz7tUOenn35Snz59VLlyZeXNm1dFihRRgwYNtHr1apfL/PLLL1WnTh0VKFBA+fPnV82aNfXZZ59luE3XS05OVlRUlMP9XqdNmyaLxZKj44vFYtGwYcNu2+X/9ttv8vX1dXrtAsg6wiEAZJPdu3dr+PDh/9hwmJiYqGHDhik8PFzjxo3T4sWL9dRTT2nSpEmqU6eOEhMTHeq/8cYbeuaZZ9SqVSstW7ZMvXv31siRI9WnTx+Hem+99ZYuX76sl19+WUuXLtWIESO0bds23XXXXdq1a5fb9gwZMkQJCQlup7/77rs6e/asHn74Yfn6+rqtd+bMGT3wwAP67bff9Mknn2jevHm6cuWKoqOjtW/fPnu9n376SdOnT1f9+vU1ffp0ffnll6pbt6569eqV4U3Pjx07psGDB7u9OfjtwNNtb9WqlT799FMNHTpUS5YsUY0aNdSuXTvNmjXLXsfT/ckmNTVV3bp1U6FChVxOP3DggGbOnClfX181bdo0w+1at26dmjRpoiJFimjhwoUaP368Vq5cqfr16yspKcleb/bs2frhhx/UrVs3LVy4UJMnT5afn5+9P673ySef6NFHH1XRokU1c+ZMzZkzR2XLllWnTp307rvvZtgemwkTJiguLk79+vWzlzVr1kybNm1S0aJFs7SMW9GmTZvUvXv3HFt+hQoV1KFDBz377LM5tg7gHy9X77IIALnE3U2ob8bnn39uJJk1a9Zk2zJvJSkpKS5vPG7b7s8++8xe9tdffxl/f3/To0cPh7pvvPGGsVgsZteuXfayU6dOOS3z2LFjxsfHxzz55JMu27Jlyxbj6+trX7ermxmnpqba/2+1Wp1u7G7zn//8x/j4+JhDhw7Zy86fP28KFSpk2rRpYy87d+6cuXr1qtP8ffr0MZLMkSNHXC6/efPm5qGHHrqhmzz/HVzd9D49T7b922+/NZLMrFmzHOrGxsaaYsWKmZSUFGOMZ/vT9caMGWOKFy9uxo8f7/Im29c/71u3bnW6Af31atSoYSpVqmSSk5PtZd9//72RZCZMmGAvc7WPpqSkmCpVqpiyZcs6lNepU8eEh4c7tCMtLc1ERUWZKlWquGzH9ZKTk03x4sXNCy+8kGnd7KZMbmR/O/jxxx+NJPP999/ndlOA2xJHDgH8q125ckUDBw5UWFiYAgICVLduXW3bts2p3o8//qiHH35YBQoUkL+/v6pXr6558+bZp0+bNk2PPfaYJCkmJkYWi8V+OtsHH3ygPHnyOJyq9vbbb8tisTgcRUtLS1NISIgGDRpkL7t69apGjBhhPzWzcOHC6tq1q86cOePUxrlz5+q+++6T1WpVUFCQGjVq5LQtXbp0UVBQkA4cOKCmTZsqKChIJUuW1KBBgxyOlLji5eWlggULOpXXrFlTkvTnn3/ay5YuXaorV66oa9euDnW7du0qY4wWLFhgLwsNDXVaZrFixVSiRAmHZV7fJ926dVOfPn10zz33uG1vnjxZe4v76quvVK9ePYWHh9vLgoOD1apVK33zzTdKSUmRJIWEhMjHx8dpftv2Hz161GnajBkztG7dOk2YMCFLbbH58ccf1bZtW0VERNhPtW3Xrp0OHz7sUM92quGaNWvUq1cvFSpUSAULFlSrVq10/Phxh7rJycl67rnnFBYWpsDAQN1///364YcfstQeT7b9q6++UlBQkP31YNO1a1cdP35cW7ZskeTZ/mSzf/9+vfrqq5owYYKCg4NdtjWrz/uxY8e0detWdezYUd7e/7uzV+3atVWhQgV99dVX9jJX+6iXl5fuvvtup3b6+PgoKCjIoR0Wi0XBwcHy9/fPtF1ff/21jh07po4dOzqUuzqtNDo6Wnfeeae2bt2qBx54QIGBgSpTpoxGjRqltLQ0h/nj4+M1aNAglSlTRn5+fgoNDVXTpk21d+9et20ZNmyYLBaLU7mrtqxevVrR0dEqWLCgAgICVKpUKbVu3VqXL1926AfbaaXbt2+XxWLRlClTnJa/ZMkSWSwWff311/ay/fv3q3379goNDZWfn58qVqyoDz74wGneu+++WxUrVtTEiRPdbhcA9wiHAP7VXnrpJR08eFCTJ0/W5MmTdfz4cUVHR+vgwYP2OmvWrFGdOnUUHx+viRMnauHChapWrZoef/xx+2+ZmjVrppEjR0qSPvjgA23atEmbNm1Ss2bN1KBBAxljtGrVKvsyV65cqYCAAK1YscJe9uOPPyo+Pt5+L6W0tDS1aNFCo0aNUvv27fXtt99q1KhRWrFihaKjox1Ouxs5cqTatWunSpUqad68efrss8908eJFPfDAA9q9e7fDNicnJ+vhhx9W/fr1tXDhQnXr1k3vvvuu3nrrrRvqQ9vvru644w572c6dOyVJlStXdqhbtGhRFSpUyD7dnYMHD+rw4cMOy7R57bXXlJCQoNdff/2G2nu9xMRE/f7776pSpYrTtCpVqigxMdFhX3Bl9erV8vb2VoUKFRzKT58+rQEDBmjUqFEqUaKER+06dOiQIiMjNW7cOC1btkxvvfWWTpw4oRo1auivv/5yqt+9e3f5+Pho1qxZGj16tNauXasnnnjCoc5TTz2lsWPHqlOnTlq4cKFat26tVq1aKS4uzqO2Xc/Vtu/cuVMVK1Z0CFyS7H2c2XPvan+SJGOMunfvrubNm+vhhx++4TZf387r25W+rZm1MyUlRevXr3dqZ79+/bRnzx698cYbOnPmjP766y+NHTtWP/30kwYPHpxpu7799luFhoaqUqVKWdqOkydPqkOHDnriiSf09ddfq0mTJnrxxRc1Y8YMe52LFy/q/vvv10cffaSuXbvqm2++0cSJE1WhQgWdOHEiS+vJyKFDh9SsWTP5+vrqk08+0dKlSzVq1ChZrVZdvXrV5TxVq1ZV9erVNXXqVKdp06ZNs4dX6dop+zVq1NDOnTv19ttva9GiRWrWrJn69++v4cOHO80fHR2tJUuWyHC3NsBzuXvgEgByh+200rvuusukpaXZyw8dOmR8fHxM9+7d7WVRUVGmevXqDqeeGXPtdMGiRYvaTx/L6LTSEiVKmG7duhljjElKSjJWq9U8//zzRpI5fPiwMebaKZc+Pj7m0qVLxhhjZs+ebSSZL7/80mFZtlPlbKe9HTlyxHh7e5t+/fo51Lt48aIJCwtzODWyc+fORpKZN2+eQ92mTZuayMjIzDsunaNHj5oiRYqYe+65x+E0uqeeesr4+fm5nKdChQqmYcOGbpeZnJxsoqOjTXBwsNOpmtu2bTM+Pj5m6dKlxhhj/vjjD7enlV7P3Wmlx44dM5LMm2++6TRt1qxZRpLZuHGj2+UuW7bM5MmTxzz77LNO01q3bm1q165t379u5rTSlJQUc+nSJWO1Ws348ePt5VOnTjWSTO/evR3qjx492kgyJ06cMMYYs2fPHiPJqZ0zZ840kjI9rdQVd9tevnx506hRI6f6x48fN5LMyJEj3S7T3f5kjDHvv/++CQkJMSdPnjTG/G/b059Wer2MTiu1bfumTZucpvXo0cP4+vq6Xa4xxrz88stGklmwYIHTtAULFph8+fIZSUaSCQgIMDNmzMhweTYVK1Y0jRs3diq3be8ff/xhL6tbt66RZLZs2eJQt1KlSg7PwWuvvWYkmRUrVmS4bqU7rXTo0KHG1UfF9G354osvjCTzyy+/eLT89957z0gy+/bts5edO3fO+Pn5mUGDBtnLGjVqZEqUKGHOnz/vsLy+ffsaf39/c+7cOYfyjz/+2Egye/bsybA9AJxx5BDAv1r79u0dTpsKDw9X7dq1tWbNGknXLm6xd+9edejQQdK1owW2v6ZNm+rEiRMOFy1xp379+lq5cqUkaePGjbp8+bIGDhyoQoUK2Y8e2q6aaLVaJUmLFi1S/vz59dBDDzmst1q1agoLC9PatWslScuWLVNKSoo6derkUM/f319169a117OxWCx66KGHHMqqVKnidMpiZs6dO6emTZvKGKO5c+c6nc7n6nS0zKYZY/Tkk09q/fr1mj59ukqWLGmflpKSom7duunxxx9Xo0aNPGprZm6krT///LPatGmjWrVq6c0333SY9uWXX+qbb77Rxx9/nOGy3bl06ZKef/55lStXTt7e3vL29lZQUJASEhK0Z88ep/rpj6TZjobZnlPb/mzbj23atGnjdIQvKzLadunG+jOj/enw4cN68cUXNWbMGBUpUsTj9mbEXXsy2obJkyfrjTfe0KBBg9SiRQuHaUuXLtUTTzyhVq1aacmSJVqxYoW6d++uLl26uDxKlt7x48ddnsbqTlhYmP1UXJv0r+clS5aoQoUK9rMSslu1atXk6+urHj166NNPP830aLtNhw4d5Ofn53A12dmzZyspKcl+SvqVK1e0atUqPfLIIwoMDHQag69cuaLNmzc7LNfWf8eOHcueDQT+RQiHAP7VwsLCXJadPXtWknTq1ClJ0uDBg+Xj4+Pw17t3b0lyeZpfeg0aNNCRI0e0f/9+rVy5UtWrV1doaKjq1aunlStXKjExURs3bnT48Hbq1CnFx8fL19fXad0nT560r9fWxho1ajjVmzt3rlP7AgMDnX775OfnpytXrmS12xQXF6fY2FgdO3ZMK1asUJkyZRymFyxYUFeuXHH4vZHNuXPnVKBAAady8/+nDc6YMUPTpk1z+tA9btw4HTx4UEOHDlV8fLzi4+N14cIFSdc+QMbHx2d6S4n0QkJCZLFY7M93+nZKctnWbdu2KTY2VuXLl9fixYvl5+dnn3bp0iX16dNH/fr1U7FixexttZ1eFx8fn+FVVqVrX1r897//Vffu3bVs2TL98MMP2rp1qwoXLuzyKp7pf7tna4+trm370u/v3t7eLn/3l5GMtt3WFk/7M7P9qU+fPrrzzjvVunVre3/a9q1Lly7p/PnzHm2DrZ2S3LbVVTslaerUqerZs6d69OihMWPGOEwzxqhbt2568MEH9cknn6hx48Zq0KCB3nvvPbVv3179+vXL9LlPTEzM0m8T02/H9fz8/Bz2kzNnznh8arMnypYtq5UrVyo0NFR9+vRR2bJlVbZsWY0fPz7D+QoUKKCHH35Y06dPt792p02bppo1a9pP1z179qxSUlL0/vvvO41vttNO049xtv5zd8VbAO55/nUhAPyDnDx50mWZ7QOX7XL5L774olq1auVyGZGRkZmup379+pKuHR1csWKFYmNj7eWvvPKKvvvuOyUlJTmEQ9vFRZYuXepymXnz5nVo4xdffOFwUZWcEhcXpwYNGuiPP/7QqlWrXP5my/Zbwx07dujee++1l9tC7Z133ulQ3xYMp06dqilTpjj9Xk669hux8+fPq3z58k7ThgwZoiFDhmjbtm2qVq1alrclICBA5cqV044dO5ym7dixQwEBAU5BZdu2bWrQoIHCw8O1fPly5cuXz2H6X3/9pVOnTuntt9/W22+/7bTckJAQtWjRwuGiPNc7f/68Fi1apKFDh+qFF16wlyclJdkDlqds+/PJkydVvHhxe3lKSorLcOROZtsuXXvuZ8+erZSUFIejkrY+Tv/cZ2V/2rlzpw4fPqyQkBCnaTExMcqXL1+m90ZMz9aOHTt2ON3yYseOHU7tlK4Fw+7du6tz586aOHGi09HFU6dO6cSJE+rZs6fTvDVq1ND06dN16NAhl7+ltSlUqNANP8/uFC5c2OUFkzJjC1lJSUkOXwK4+kLsgQce0AMPPKDU1FT9+OOPev/99zVgwAAVKVJEbdu2dbuOrl276vPPP9eKFStUqlQpbd26VR9++KF9ekhIiLy8vNSxY0en2+DYlC5d2uGxrf/c3e4EgHuEQwD/arNnz9bAgQPtH/IOHz6sjRs3qlOnTpKuBb/y5ctr+/bt9gvOuJP+aM31ihYtqkqVKunLL7/UTz/9ZF9WbGysevbsqXfeeUfBwcGqUaOGfZ7mzZtrzpw5Sk1NdQhY6TVq1Eje3t76/fff1bp1a886wEO2D/IHDx7UihUrVL16dZf1GjduLH9/f02bNs2h7barHLZs2dJeZozRU089palTp9ovmOHKCy+84HSz9pMnT6pdu3Z6+umn9fjjj6tcuXIeb9MjjzyicePG6c8//7Sfxnrx4kXNnz9fDz/8sEPA+eWXX9SgQQOVKFFCK1ascBlWwsLC7KdxXm/UqFFat26dlixZkuGHVovFImOM0xG5yZMne3xk1CY6OlqSNHPmTN1999328nnz5tmvxpqZrGy7dK0/P/74Y3355Zd6/PHH7eWffvqpihUr5rA/ZHV/mjNnjtOR7aVLl+qtt97SxIkTMwxb7hQvXlw1a9bUjBkzNHjwYHl5eUmSNm/erH379mnAgAEO9adNm6bu3bvriSee0OTJk12edhoSEiJ/f3+n0xyla/f4y5MnT6b3KYyKitLvv//u8fZkpEmTJnr11Ve1evVq1atXL8vzRURESJJ+/fVXh7Hpm2++cTuPl5eX7r33XkVFRWnmzJn6+eefMwyHDRs2VPHixTV16lSVKlVK/v7+ateunX16YGCgYmJitG3bNlWpUiXDe5baHDx4UHny5MnSF3cAHBEOAfyrnT59Wo888oieeuopnT9/XkOHDpW/v79efPFFe52PPvpITZo0UaNGjdSlSxcVL15c586d0549e/Tzzz/r888/l/S/IxGTJk1S3rx55e/vr9KlS9uP2tSvX1/vv/++AgICVKdOHUnXvvEuXbq0li9f7hRE2rZtq5kzZ6pp06Z65plnVLNmTfn4+Ojo0aNas2aNWrRooUceeUQRERF67bXX9PLLL+vgwYNq3LixQkJCdOrUKf3www+yWq0ur+jnqcTERPvtMcaNG6eUlBSHD8GFCxdW2bJlJV07XeyVV17RkCFDVKBAATVs2FBbt27VsGHD1L17d4crMfbv319TpkxRt27dVLlyZYdl+vn52QNDVFSUoqKiHNpku5R+2bJl7QHIZt26dfZbfqSmpurw4cP64osvJEl169ZV4cKFJV07Zfizzz5Ts2bN9Nprr8nPz0+jRo3SlStX7Jfdl6R9+/bZj+y+8cYb2r9/v/bv32+fXrZsWRUuXFj+/v5ObZGuhQsvLy+X064XHBysBx98UGPGjFGhQoUUERGhdevWacqUKcqfP3+G87pTsWJFPfHEExo3bpx8fHzUoEED7dy5U2PHjnV7S4jrZXXbpWtBJDY2Vr169dKFCxdUrlw5zZ49W0uXLtWMGTPsIcyT/alWrVpObbI993fffbfTLU1sz7Ptt28//vijgoKCJEmPPvqovd5bb72l2NhYPfbYY+rdu7dOnz6tF154QXfeeafDlxSff/65nnzySVWrVk09e/Z0ugVI9erV5efnJz8/P/Xu3VvvvPOOOnXqpMcff1xeXl5asGCBZs2apSeffNLt6ao20dHReu2113T58mUFBgZmWDerBgwYoLlz56pFixZ64YUXVLNmTSUmJmrdunVq3ry5YmJiXM7XtGlTFShQQE8++aRee+01eXt7a9q0aU6375g4caJWr16tZs2aqVSpUrpy5Yo++eQTScr0d45eXl7q1KmT/QuyVq1aOR2RHj9+vO6//3498MAD6tWrlyIiInTx4kUdOHBA33zzjf0KtzabN29WtWrV3H6BASADuXctHADIPbarlX722Wemf//+pnDhwsbPz8888MAD5scff3Sqv337dtOmTRsTGhpqfHx8TFhYmKlXr56ZOHGiQ71x48aZ0qVLGy8vL6erJC5cuNBIMrGxsQ7zPPXUU0aSee+995zWm5ycbMaOHWuqVq1q/P39TVBQkImKijI9e/Y0+/fvd6i7YMECExMTY4KDg42fn58JDw83jz76qFm5cqW9jrsrZrq7KuH1bFcGdffn6oqX48ePNxUqVDC+vr6mVKlSZujQoU43Uw8PD3e7zPDw8Cy1ydXVSm1XcnT1l/6KsgcOHDAtW7Y0wcHBJjAw0NSvX9/89NNPDnVsV2h09+fuRus2nlyt9OjRo6Z169YmJCTE5M2b1zRu3Njs3LnT6Yb17q7Yadu/r9/OpKQkM2jQIBMaGmr8/f1NrVq1zKZNm5yW6Yqn237x4kXTv39/ExYWZnx9fU2VKlXM7NmzHercyP7kqk2urlaa0XLTW758ualVq5bx9/c3BQoUMJ06dXK66b3tKr/u/q6/gmhqaqr5+OOPzT333GPy589vgoODTfXq1c1///tfp33flQMHDhiLxeJ0RWF3Vyu94447nJbRuXNnp9dOXFyceeaZZ0ypUqWMj4+PCQ0NNc2aNTN79+516LfrryZqjDE//PCDqV27trFaraZ48eJm6NChZvLkyQ5t2bRpk3nkkUdMeHi48fPzMwULFjR169Y1X3/9tcOyXC3fGGN+++03e1+6u6LqH3/8Ybp162aKFy9ufHx8TOHChU3t2rXNiBEjHOpdvHjRBAYGmrffftvlcgBkzGIMN4EBAAC4VdiuULxkyZLcbsptZ8qUKXrmmWf0559/cuQQuAGEQwAAgFvIzp07Vb16dW3cuNHht37IWEpKiipVqqTOnTvr5Zdfzu3mALclbmUBAABwC7nzzjs1depUl1dThnt//vmnnnjiCQ0aNCi3mwLctjhyCAAAAADgyCEAAAAAgHAIAAAAABDhEAAAAAAgyTvzKrjdpKWl6fjx48qbN68sFktuNwcAAABALjHG6OLFiypWrJjy5Mn42CDh8B/o+PHjKlmyZG43AwAAAMAt4s8//1SJEiUyrEM4/AfKmzevpGs7QHBwcK60ITk5WcuXL1fDhg3l4+OTK234p6OPcxb9m/Po45xF/+Y8+jhn0b85jz7OWbdK/164cEElS5a0Z4SMEA7/gWynkgYHB+dqOAwMDFRwcDCDTQ6hj3MW/Zvz6OOcRf/mPPo4Z9G/OY8+zlm3Wv9m5edmXJAGAAAAAEA4BAAAAAAQDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAuoXCYXR0tAYMGOBUvmDBAlksFknStGnTZLFY1LhxY4c68fHxslgsWrt2rb3MYrFowYIF9sfJyclq27atihYtql9//VWSFBERIYvFos2bNzssb8CAAYqOjnYoO3funAYMGKCIiAj5+vqqaNGi6tq1q44cOWKvM3HiROXNm1cpKSn2skuXLsnHx0cPPPCAw/LWr18vi8Wi3377zeO2AAAAAEB2887tBnjK29tbq1at0po1axQTE5OleS5fvqzWrVvrt99+04YNG1S2bFn7NH9/fz3//PNat26d2/nPnTunWrVqydfXVxMmTNCdd96pQ4cO6ZVXXlGNGjW0adMmlSlTRjExMbp06ZJ+/PFH1apVS9K1EBgWFqatW7fq8uXLCgwMlCStXbtWxYoVU4UKFTxqy+1m14l4XbxqlD/AR4WC/FQ0X2BuNwnINXEJSTp18YrOX0lW/gAfhQb5K8Tql9vNyhaebltcQpKOx12SJO0/fUFF8we5rZ/d/Xb98vL6+cjPK4/OJSYp2D9ry85qe3L7+Y6/fFWS9OORsyoQFJBj67dtZ9zlqwry85ZXHou8vSwqbP3n7N83Ky4hSScuJOrc5asK8vOR1ddLFkmXk1N18UqKgvy8FeTnrcTkFMUnJitfgI8sssjLYuTr7a2LSclKSEpV/gBv+Xl7KTE5TeevXFtWoI+XUk2avCx5lJyaJklKNUYJSSkqYPXT1ZQ0XUpKVgGr7z9qzMGNjTHp5yngf9tFgVtOXEKSziVcVUJyiiwWiywyssiiVGN08fIVSdfG48L5fHK5pVlz2+0RVqtVbdq00QsvvKAtW7ZkWj8+Pl7NmzfXhQsXtGHDBhUtWtRhes+ePfXhhx9q8eLFatq0qctlvPzyyzp+/LgOHDigsLAwSVKpUqW0bNkylS9fXn369NGSJUsUGRmpYsWKae3atfZwuHbtWrVo0UJr1qzRxo0b1aBBA3t5+nCblbbcLv44e+1DX+23lysx9VpZg8gwTWxXU2UL5c3FlgG548+4BHWfuVnL9560lzWMCtPkDrVUMsSaiy27eZ5um63++v0nNbtekO4ZvVQPlHddP7v7zdXy6keG6ZnoSMWMX6U6ZQpluOystie3n+8/4xLUa9YmPVVCqv/eKiWm5sz6M+rP/2zcpv+2qXHb7983K30fWX29tejpaI1cvlMrruu3BpFh6h8dqXZTv1fC1RQ9XLm4Rj5cTU/P+UEr952U1ddbc7vdr/Fr9zrMVz8yTO8/do9eWbRdHWuW1vi1+7T5j780u2sdDfn2V63a988bc3BjY4yreZpVLKKnSuR4c/+xjsYl6MBflzR21R71rFNOH31/QD3rlNP4tfu0at9JBXhJs+sFqeuMTfqw/X23xWvvljmt1BPDhg3Tjh079MUXX2RY7+TJk6pbt67S0tK0bt06p2AoXTud8+mnn9aLL76otLQ0p+lpaWmaM2eOOnToYA+GNgEBAerdu7eWLVumc+fOSbp2euyaNWvsddasWaPo6GjVrVvXXn716lVt2rTJKRxm1pbbxYnzlzXgi5+cylfuO6mnZ/+gE+cv50KrgNwTl5Dk9IYsScv3nlT3mZsVl5CUSy27eZ5umyf1s7vf3C1v1b6TGr92nwbERGW47Ky2J7efb9v6V/92KkfXn1l/Vi4Wctvv3zfLVR8NiInSiGWOwVC69h5p2w8lqXKxEA344iet/P9wNyAmSuPSBUPpWn/3//xHezBcte+kBsRE2f9/vX/CmIMbG2PczWMbJ2xnGiDr4hKStGT3cY1YulPViodo/Np99n/Tv/ZW/3bqtnnt3XZHDiWpWLFieuaZZ/Tyyy+rZcuWbus988wzKlOmjDZt2mQ/ndOVV155RVOnTtXMmTPVsWNHh2lnzpxRfHy8Klas6HLeihUryhijAwcOqGbNmoqOjtazzz6rlJQUJSYmatu2bXrwwQeVmpqq9957T5K0efNmJSYmujwtNqO2uJOUlKSkpP/tbBcuXJB07XeWycnJWVpGdjp1PkFbDp5Sz5JBCvBynPb9gZM6dT5BhQJvj0PrtzLbc5sbz/G/QXb27/G4S1q//6TT60GS1u8/qeNxlxTke1t+V+fxtl1f3zaP7d/09bO73zJa3sYDJ/VM3fIK8HK/7Ky2J7ef7/Trv74d2bn+rPTnOyt33tb7d2YyGydc9dG94SF6Z+XOTPfD9PUymu/7Ayc1svmd2njgpMt5r3c7jTm8z7l2I2OMu3lsj0/GX1L+QN8cavE/0/G4SwrL6+cw3tn+TT/+ZvTe8nfw5DVkMcaYHGxLlkVHR6tatWoaN26cQ/mCBQv0yCOPyBijadOmacCAAYqPj1d8fLzKlCmjUaNGqU2bNgoJCbEfpZOuXZCmdevW+uqrrzR27Fg9++yzTuuMiIjQgAEDNGDAAL322muaOnWq9u3bp+eee06//PKL1q5dq1OnTiksLEzvvvuuywvmzJ8/X61bt9YPP/ygGjVq6MCBAypfvrw2btyouLg4/ec//9GuXbt08uRJlSpVSnFxcXr77bc1ZcoUHT582KO2uDNs2DANHz7cqXzWrFkZhmIAAAAA/2yXL19W+/btdf78eQUHB2dY95Y5chgcHKzz5887lcfHx7vciPz58+vFF1/U8OHD1bx5c5fLfOKJJ/Twww+rW7duSk1N1eDBg92uf+DAgZowYYImTJjgUF64cGHlz59fu3fvdjnf3r17ZbFY7Be5KVeunEqUKKE1a9YoLi5OdevWlSSFhYWpdOnS+v7777VmzRrVq1fP47a48+KLL2rgwIH2xxcuXFDJkiXVsGHDTHeAnLDrRLzqj1uuT+oGqdu6S/bfHNpsHNRQdxTN/7e3658mOTlZK1asUGxsrHx8OBKb3bKzf387dUE1xix1O33rfxqrQpG//7WaHTzdtuvrB3jJaZy4vn5291tmy5v75AN6fMp6t8vOanty+/m2rd9V/2bn+rPan7fz/p2ZzMYJV310/X7mim16+nqZzbduQAPVHbcyS3Vvl+eE9znXbmSMcTePbZwoU62WoooVyPa2/pP9duqCDp5LcHi9pn/tpR+Hc+u1ZzurMCtumXAYFRWlJUuWOJVv3bpVkZGRLufp16+f3nvvPY0fP97tcjt16iQvLy917txZaWlpeu6551zWCwoK0pAhQzRs2DA99NBD9vI8efKoTZs2mjlzpl577TWH3x0mJiZqwoQJatSokQoU+N8LKiYmRmvXrrUfObSpW7euli1bps2bN6tr165u2+yuLe74+fnJz8/56lQ+Pj65MpgWyWfVvWWKSEpQYqocPpQ0iAxTkXxWBvlslFvP879FdvRvsZAgPVA+zOm3HtK1CwgUCwm6bZ9DT7fNVX3bOJG+fnb3W0bLqx8Zpi2H41y2w9Ntze3n27b+9fuvrf/6cTg715+V/nyg/O29f2eVu3HCVR9tORyn2uXCnH6TJDnuh1sOx6lOuTD7bw63HI7T/eXDnH5zKF17bz15Kdm+3IzWcTuOObzPObqRMSajeSQpLP/ttU/cCoqFBGnj4XOqXS7M/ppz99pLTFWujoeerPOWOeG8d+/e+v3339WnTx9t375dv/32mz744ANNmTLFIWBdz9/fX8OHD7f/ls+dDh066LPPPtNLL72kUaNGua3Xo0cP5cuXT7Nnz3Yof+ONNxQWFqbY2FgtWbJEf/75p7777js1atRIycnJ+uCDDxzqx8TEaMOGDfrll1/sRw6la+Hw448/1pUrVzK9DYe7ttwOiuYL1LhH73YqbxAZpo/a1eR2FvjXCbH6aXKHWmoY5XhRK9uV5W7nS8t7um2e1M/ufnO3PNvVNcet2ZvhsrPantx+vm3rr1ehSI6uP7P+3HE87rbfv2+Wqz4at2avXml0p1O/NbhuP5SkHcfjNO7Ru9UgMsw+3zPRUS77+73H7tGMH/7QM9GRqh8Z9v91r/3/ev+EMQc3Nsa4m8c2TvB7Q8+FWP3UpFIxvdL4Tv1yLE7PREfa/03/2qtXocht89q7ZX5zKEk//fSTXn75ZW3btk1XrlxRhQoVNGjQILVt21aSHH5zaJOamqoqVapo9+7dTr85/OqrrxwuWDNv3jx16NBBw4cP10svveTwOz+b2bNnq3379qpbt67D7/z++usvvfbaa1qwYIFOnDihggULqnHjxnrttddUqlQph+04dOiQSpcuraioKO3Zs8defvToUZUsWVJly5bVgQMHHObxpC2ZuXDhgvLly5el84pzSnJyshYvXqzw6rV18apRvgAfFeY+h9nK1sdNmzbl274ckBP9e/39pfL5+6hI3n/OPcc83TbbfQ4P/LRB5e6+X8VCsnafw+zoN8f7HHrLz8tL5xKTlNcva8vOanty+/k+cz5BG9euVOid9yrEGpBj67ff5zDxqqy+3vLOY5FXHsu/4p56WR0nbPc5jLt8VVY/bwX6eiuP/nefQ6ufl/L6+SgxOUXnE5MV7O+jPBaLLBYjv+vuc5gvwFv+Dvc59FaAj7fSTJryWPIoJTVNskipaenuc3g1WSEBvrfdmMP7XMZuZIxJP0/BAG9tXLuSPr4J19/nMI/FIsnIYrEoNc3oYuIV/bXrB9WObqDC+XLvNhaeZINbKhwie9xK4ZDBJufQxzmL/s159HHOon9zHn2cs+jfnEcf56xbpX89yQa3zGmlAAAAAIDcQzgEAAAAABAOAQAAAACEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAAdBuEwy5duqhly5ZO5WvXrpXFYlF8fLzDY4vFojx58ihfvnyqXr26nnvuOZ04ceKm27FhwwbVqVNHBQsWVEBAgKKiovTuu+861Pn444/1wAMPKCQkRCEhIWrQoIF++OEHhzoffvihqlSpouDgYAUHB+u+++7TkiVL3K63Z8+eslgsGjdu3E1vAwAAgKfiEpK09+R5bTn0l347fV4nzl+2P9536trjfaf+9zguIemGlpX+8f7TF25q/sza8m8Sl5Ckg2cu6rfTF7TjWJy+//20dh6P1+GzlyRJvx6L04YD18r+PHcpl1uL3OSd2w3Ibvv27VNwcLAuXLign3/+WaNHj9aUKVO0du1aVa5c+YaXa7Va1bdvX1WpUkVWq1UbNmxQz549ZbVa1aNHD0nXAmq7du1Uu3Zt+fv7a/To0WrYsKF27dql4sWLS5JKlCihUaNGqVy5cpKkTz/9VC1atNC2bdt0xx13OKxzwYIF2rJli4oVK3bD7QYAALhRf8YlqPvMzVq+96Ssvt6a3bWO3lu7Tyv3nbTXaRAZpv7RkWo39XslXE1Rw6gwTe5QSyVDrFlelqtlB3hJs+sF6Vj8ZUUUzufx/JLctuXf5Ghcgv44myBJGrF0h5bv/V//NKtYRE+VkBp/sEZ/JaZIutZnEx6vqbKF8+ZKe5G7bvkjh54KDQ1VWFiYKlSooLZt2+r7779X4cKF1atXr5tabvXq1dWuXTvdcccdioiI0BNPPKFGjRpp/fr19jozZ85U7969Va1aNUVFRenjjz9WWlqaVq1aZa/z0EMPqWnTpqpQoYIqVKigN954Q0FBQdq8ebPD+o4dO6a+fftq5syZ8vHxuam2AwAAeCouIckexiRpQEyUxqcLX5K0ct9JjV+7TwNioiRJy/eeVPeZmx2O2mW2LHfLlqS+87bqxPnLNzS/q7b8m8QlJGnJ7uPac/K8Xk8XDCVp9W+nJEm9HqhgL1u+96R6z/1BhzmC+K/0jztymF5AQICefvppPfvsszp9+rRCQ0OzZbnbtm3Txo0bNWLECLd1Ll++rOTkZBUoUMDl9NTUVH3++edKSEjQfffdZy9PS0tTx44d9Z///MfpaKIrSUlJSkr636B34cK10zCSk5OVnJyc1U3KVrb15tb6/w3o45xF/+Y8+jhn0b8575/ex8fjLmn9/pMK8Lr2+N7wEL2zcqf98fU2HjipZ+qWt09bv/+kjsddUpBvniwty9Wybf/f9PspnTqf4PH8Nunb8m9yPO6SwvL6SZI2XNd/NrbH95TK7zBt/f6TiruUqGL/Py9uzK0yRniyfosxxuRgW25aly5dNGPGDPn7+zuUp6am6sqVK4qLi1P+/Pm1du1axcTE2B9fb+nSpWrSpIm2bNmimjVr3lR7SpQooTNnziglJUXDhg3TkCFD3Nbt06ePli1bpp07dzq0f8eOHbrvvvt05coVBQUFadasWWratKl9+ptvvqk1a9Zo2bJlslgsioiI0IABAzRgwACX6xk2bJiGDx/uVD5r1iwFBgbe+MYCAAAAuK1dvnxZ7du31/nz5xUcHJxh3dviyGFMTIw+/PBDh7ItW7boiSeeyNL8tvxrsVhuui3r16/XpUuXtHnzZr3wwgsqV66c2rVr51Rv9OjRmj17ttauXesUbCMjI/XLL78oPj5eX375pTp37qx169apUqVK+umnnzR+/Hj9/PPPWW7viy++qIEDB9ofX7hwQSVLllTDhg0z3QFySnJyslasWKHY2FhOi80h9HHOon9zHn2cs+jfnPdP7+PfTl1QjTFL7Y/nPvmAHp+y3m399NO3/qexKhQJztKyXC07wEv6pG6Quq27pFUDGqr228s9mv9617fl3+S3Uxd08Ny13xu66h9bH1vCq6jt1I0O0zYOaqg7iub/O5r5j3WrjBG2swqz4rYIh1ar1X4BF5ujR49mef49e/ZIkiIiIm66LaVLl5YkVa5cWadOndKwYcOcwuHYsWM1cuRIrVy5UlWqVHFahq+vr3177rnnHm3dulXjx4/XRx99pPXr1+v06dMqVaqUvX5qaqoGDRqkcePG6dChQ07L8/Pzk5+f82F/Hx+fXH+zuhXa8E9HH+cs+jfn0cc5i/7Nef/UPi4WEqQHyofZf6e25XCcapcL0yoXvwusHxmmLYfjlJh67XHDqDAVCwmy90tmy8po2feVLaIi+aw3PH/6tvybFAsJ0sbD52SMHPovvR+PxNufO+lan4UEBfwr+ywn5PYY4cm6//EnXycmJmrSpEl68MEHVbhw4WxdtjHG4bd+kjRmzBi9/vrrWrp0qe655x6Pl9OxY0f9+uuv+uWXX+x/xYoV03/+8x8tW7YsW9sPAADgTojVT5M71FLDqDBJ0rg1e/VMdKQaRIY51GsQGaZnoiM1bs1eSf+7QmiI1S/Ly3K3bEn6b5saKpov8Ibmd9WWf5MQq5+aVCqmimH59Erjyvb+s6lXoYgk6cP1v9nLbFcrDS8Q9Le2FbeG2+LIoSdOnz6tK1eu6OLFi/rpp580evRo/fXXX5o/f/5NLfeDDz5QqVKlFBV17UpcGzZs0NixY9WvXz97ndGjR2vIkCGaNWuWIiIidPLktW9ngoKCFBR07QX20ksvqUmTJipZsqQuXryoOXPmaO3atVq69NqpFgULFlTBggUd1u3j46OwsDBFRkbe1DYAAAB4omSIVXO63q9TF6/o/JVk5Q/w0fRO9+l8YrLOX0lWPn8f5Qvw0YUryVrVv77y+fuoSF5/l2Ess2WlfxzkbdGBnzaoeP7AG5o/o7b8m5QIscrq6624y1f1fpsaSkpO1YUrKQr291GAl9GuLd9paZ8YJaZK+QJ8ld/fWyUJhv9a/7hwGBkZKYvFoqCgIJUpU0YNGzbUwIEDFRbm/E2UJ9LS0vTiiy/qjz/+kLe3t8qWLatRo0apZ8+e9joTJkzQ1atX9eijjzrMO3ToUA0bNkySdOrUKXXs2FEnTpxQvnz5VKVKFS1dulSxsbE31T4AAICcEGL1cwpYRfMpw8fZsazk5GQdyMG2/Ju46jfpWh/vklSleAinkELSbRAOp02b5rI8Ojpa119oNf3j7NavXz+Ho4SuuPo9YHpTpkzxeN1ZWS4AAAAA3Ix//G8OAQAAAACZIxwCAAAAAAiHAAAAAADCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAA0A2EwyNHjsgY41RujNGRI0eypVEAAAAAgL+Xx+GwdOnSOnPmjFP5uXPnVLp06WxpFAAAAADg7+VxODTGyGKxOJVfunRJ/v7+2dIoAAAAAMDfyzurFQcOHChJslgsGjJkiAIDA+3TUlNTtWXLFlWrVi3bGwgAAAAAyHlZDofbtm2TdO3I4Y4dO+Tr62uf5uvrq6pVq2rw4MHZ30IAAAAAQI7Lcjhcs2aNJKlr164aP368goODc6xRAAAAAIC/l8e/OZw6daqCg4N14MABLVu2TImJiZLk8gqmAAAAAIDbg8fh8Ny5c6pfv74qVKigpk2b6sSJE5Kk7t27a9CgQdneQAAAAABAzvM4HA4YMEA+Pj46cuSIw0VpHn/8cS1dujRbGwcAAAAA+Htk+TeHNsuXL9eyZctUokQJh/Ly5cvr8OHD2dYwAAAAAMDfx+MjhwkJCQ5HDG3++usv+fn5ZUujAAAAAAB/L4/D4YMPPqjp06fbH1ssFqWlpWnMmDGKiYnJ1sYBAAAAAP4eHp9WOmbMGEVHR+vHH3/U1atX9dxzz2nXrl06d+6cvv/++5xoIwAAAAAgh3l85LBSpUr69ddfVbNmTcXGxiohIUGtWrXStm3bVLZs2ZxoIwAAAAAgh3l85FCSwsLCNHz48OxuCwAAAAAgl3gcDn/99VeX5RaLRf7+/ipVqhQXpgEAAACA24zH4bBatWqyWCySJGOMJNkfS5KPj48ef/xxffTRR/L398+mZgIAAAAAcpLHvzn86quvVL58eU2aNEnbt2/XL7/8okmTJikyMlKzZs3SlClTtHr1ar3yyis50V4AAAAAQA7w+MjhG2+8ofHjx6tRo0b2sipVqqhEiRIaMmSIfvjhB1mtVg0aNEhjx47N1sYCAAAAAHKGx0cOd+zYofDwcKfy8PBw7dixQ9K1U09PnDhx860DAAAAAPwtPA6HUVFRGjVqlK5evWovS05O1qhRoxQVFSVJOnbsmIoUKZJ9rQQAAAAA5CiPTyv94IMP9PDDD6tEiRKqUqWKLBaLfv31V6WmpmrRokWSpIMHD6p3797Z3lgAAAAAQM7wOBzWrl1bhw4d0owZM/Tbb7/JGKNHH31U7du3V968eSVJHTt2zPaGAgAAAAByjkfhMDk5WZGRkVq0aJGefvrpnGoTAAAAAOBv5tFvDn18fJSUlORwX0MAAAAAwO3P4wvS9OvXT2+99ZZSUlJyoj0AAAAAgFzg8W8Ot2zZolWrVmn58uWqXLmyrFarw/T58+dnW+MAAAAAAH8Pj8Nh/vz51bp165xoCwAAAAAgl3gcDqdOnZoT7QAAAAAA5CKPf3MIAAAAAPjn8fjIoSR98cUXmjdvno4cOaKrV686TPv555+zpWEAAAAAgL+Px0cO33vvPXXt2lWhoaHatm2batasqYIFC+rgwYNq0qRJTrQRAAAAAJDDPA6HEyZM0KRJk/Tf//5Xvr6+eu6557RixQr1799f58+fz4k2AgAAAABymMfh8MiRI6pdu7YkKSAgQBcvXpQkdezYUbNnz87e1gEAAAAA/hYeh8OwsDCdPXtWkhQeHq7NmzdLkv744w8ZY7K3dQAAAACAv4XH4bBevXr65ptvJElPPvmknn32WcXGxurxxx/XI488ku0NBAAAAADkPI+vVvryyy+rePHikqSnn35aBQoU0IYNG/TQQw9xQRoAAAAAuE15HA7LlSunEydOKDQ0VJLUpk0btWnTRmfPnlVoaKhSU1OzvZEAAAAAgJzl8Wml7n5XeOnSJfn7+990gwAAAAAAf78sHzkcOHCgJMlisejVV19VYGCgfVpqaqq2bNmiatWqZXsDAQAAAAA5L8vhcNu2bZKuHTncsWOHfH197dN8fX1VtWpVDR48OPtbCAAAAADIcVkOh2vWrJEkde3aVePHj1dwcHCONQoAAAAA8Pfy+II0U6dOzYl2AAAAAABykccXpAEAAAAA/PMQDgEAAAAAhEMAAAAAAOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAJTL4bBLly5q2bKlU/natWtlsVgUHx/v8NhisShPnjzKly+fqlevrueee04nTpzIcB3bt29Xu3btVLJkSQUEBKhixYoaP368Q50rV66oS5cuqly5sry9vV22af78+YqNjVXhwoUVHBys++67T8uWLXOqFx8frz59+qho0aLy9/dXxYoVtXjxYvv0N998UzVq1FDevHkVGhqqli1bat++fQ7LsG1r+r8xY8ZkuK0AANxq4hKStPfkeW059Jf2nTqvuISkG6qT3esEADjzzu0GeGLfvn0KDg7WhQsX9PPPP2v06NGaMmWK1q5dq8qVK7uc56efflLhwoU1Y8YMlSxZUhs3blSPHj3k5eWlvn37SpJSU1MVEBCg/v3768svv3S5nO+++06xsbEaOXKk8ufPr6lTp+qhhx7Sli1bVL16dUnS1atXFRsbq9DQUH3xxRcqUaKE/vzzT+XNm9e+nHXr1qlPnz6qUaOGUlJS9PLLL6thw4bavXu3rFarJDkF3iVLlujJJ59U69atb7oPAQD4u/wZl6DuMzdr+d6T9rKGUWGa3KGWSoZYs1wnu9cJAHDttgqHoaGhyp8/v8LCwlShQgW1aNFC1atXV69evbRhwwaX83Tr1s3hcZkyZbRp0ybNnz/fHg6tVqs+/PBDSdL3339vP2J5vXHjxjk8HjlypBYuXKhvvvnGHg4/+eQTnTt3Ths3bpSPj48kKTw83GG+pUuXOjyeOnWqQkND9dNPP+nBBx+UJIWFhTnUWbhwoWJiYlSmTBl3XQMAwC0lLiHJKaRJ0vK9J9V95mbN6Xq/JGVaJ8Tql63r9GR5APBvc1uFw/QCAgL09NNP69lnn9Xp06cVGhqapfnOnz+vAgUK3NS609LSdPHiRYflfP3117rvvvvUp08fLVy4UIULF1b79u31/PPPy8vLy21bJLltz6lTp/Ttt9/q008/dduWpKQkJSX975SZCxcuSJKSk5OVnJzs8bZlB9t6c2v9/wb0cc6if3MefZyzcrt/j8dd0vr9JxXg4u1v/f6TOh53yf7/jOoE+Wb9FzBZWacny8tMbvfxPx39m/Po45x1q/SvJ+vP9XC4aNEiBQUFOZSlpqZmef6oqChJ0qFDh7IUDjdt2qR58+bp22+/9ayh6bz99ttKSEhQmzZt7GUHDx7U6tWr1aFDBy1evFj79+9Xnz59lJKSoldffdVpGcYYDRw4UPfff7/uvPNOl+v59NNPlTdvXrVq1cptW958800NHz7cqXz58uUKDAy8ga3LPitWrMjV9f8b0Mc5i/7NefRxzsrN/p1dL8jttAM/bchSnQPZvE5Pl5cV7MM5i/7NefRxzsrt/r18+XKW6+Z6OIyJibGf0mmzZcsWPfHEE1ma3xgj6dpFXDKza9cutWjRQq+++qpiY2M9b+z/mz17toYNG6aFCxc6BNK0tDSFhoZq0qRJ8vLy0t13363jx49rzJgxLsNh37599euvv7o9JVa6dqpqhw4d5O/v77bOiy++qIEDB9ofX7hwQSVLllTDhg0VHBx8g1t5c5KTk7VixQrFxsbaT7FF9qKPcxb9m/Po45yV2/3726kLqjFmqdvpW//TWJIyrVOhSNbfx7KyTk+Wl5nc7uN/Ovo359HHOetW6V/bWYVZkevh0Gq1qly5cg5lR48ezfL8e/bskSRFRERkWG/37t2qV6+ennrqKb3yyiset9Nm7ty5evLJJ/X555+rQYMGDtOKFi0qHx8fh1NIK1asqJMnT+rq1avy9fW1l/fr109ff/21vvvuO5UoUcLlutavX699+/Zp7ty5GbbJz89Pfn7Ov6Hw8fHJ9Rf6rdCGfzr6OGfRvzmPPs5ZudW/xUKC9ED5MKff/0nXLhBTLOTaEb7M6njS9qysMyf6gn04Z9G/OY8+zlm53b+erPu2vs9hYmKiJk2apAcffFCFCxd2W2/Xrl2KiYlR586d9cYbb9zw+mbPnq0uXbpo1qxZatasmdP0OnXq6MCBA0pLS7OX/fbbbypatKg9GBpj1LdvX82fP1+rV69W6dKl3a5vypQpuvvuu1W1atUbbjMAALkhxOqnyR1qqWGU40XWbFcODbH6ZalOdq8TAOBerh859MTp06d15coVXbx4UT/99JNGjx6tv/76S/Pnz3c7jy0YNmzYUAMHDtTJk9e+TfTy8nIIlLt379bVq1d17tw5Xbx4Ub/88oskqVq1apKuBcNOnTpp/PjxqlWrln05AQEBypcvnySpV69eev/99/XMM8+oX79+2r9/v0aOHKn+/fvb19OnTx/NmjVLCxcuVN68ee3LyZcvnwICAuz1Lly4oM8//1xvv/32zXccAAC5oGSIVXO63q9TF6/o/JVk5fP3UZG8/g4hLSt1snudAADXbqtwGBkZKYvFoqCgIJUpU8Ye+NLf+uF6n3/+uc6cOaOZM2dq5syZ9vLw8HAdOnTI/rhp06Y6fPiw/bHt9hS23zR+9NFHSklJUZ8+fdSnTx97vc6dO2vatGmSpJIlS2r58uV69tlnVaVKFRUvXlzPPPOMnn/+eXt92+8ro6OjHdo5depUdenSxf54zpw5MsaoXbt2WescAABuQbYjhDdbJ7vXCQBwlqvh0Baq0ouOjraHMlePPTFs2DANGzYs03rXB0VX1q5dm6X13Xfffdq8ebPb6Vndjh49eqhHjx5ZqgsAAAAAN+u2/s0hAAAAACB7EA4BAAAAAIRDAAAAAADhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIc/l979x5VVZ3/f/x1QAQERCDlokimgOa11AzHW0qkM1OWlddJTZuxSVOW00/TpiUlA4plX8suSzMzx1LXaNhqSqVJUGskbyxveWHC2ySSMygIXkA+vz9anPFwk9vxcOj5WOusxf7szd7vz7tPZ/ninLMPAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAAAQ4RAAAAAAIMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAKiBh8OJEyfKYrFowYIFNuPJycmyWCw2Y8YYLV++XFFRUWrevLm8vb3VuXNnzZgxQ5mZmTbH5uXl6aWXXlLHjh3l4eGhoKAgRUdHa+PGjTLGVFlL2Ufnzp2txyxfvlz9+/eXn5+f/Pz8FB0dre+++87mPPn5+YqNjVVYWJg8PT3Vt29f7d692+aYuLg4dezYUV5eXtbzpKen17h/AAAAAFBdTRxdwK14eHho4cKFmjJlivz8/Co8xhijsWPHKjk5WXPnztUbb7yhVq1aKSsrSykpKYqPj9eHH34oSbp48aL69eunS5cuKT4+Xr1791aTJk2UlpamWbNmafDgwWrRokW5ayxZssQmpBYXF6t79+568sknrWOpqakaM2aM+vbtKw8PDyUlJSkmJkaHDx9W69atJUnPPPOMDh06pNWrVyskJER//etfFR0drSNHjliPiYiI0NKlS3XXXXfpypUreuONNxQTE6PMzEy1bNmynjoLAM4vt+Cazudf1aWrRWrh6aZW3h7y83Jv8Oe+3Woyl+oc6yy9ublOv2Zu8nF306UrRRVuN5R5VFVzC083NfdwU97VIl28UnXNzjh3AI7X4MNhdHS0MjMzlZiYqKSkpAqPWbdundauXatNmzbpkUcesY7fddddGjJkiM2rgXPnztXJkyd1/PhxhYSEWMcjIiI0ZswYeXh4VHgNX19f+fr6WreTk5OVm5urp59+2jq2Zs0am99Zvny5/va3v+kf//iHxo8frytXrmjDhg3atGmTBgwYIOnnVwmTk5P17rvvKj4+XpI0duxYm/MsXrxYK1as0IEDBzRkyJAq+wUAvxRncgv0zJpd2no02zoW0zFI74+7X6F+Xg323Lfbvy8Wasq6PdWaS3Xm7Sy9ublOr6ZN9MnTv9Kbqcf01bHy26UcPY+qai4VHRmk6YMiNWblNyq4Xlxhzc44dwANQ4N+W6kkubq6KiEhQW+99ZbOnj1b4TGffPKJIiMjbYLhzUrfglpSUqK1a9dq3LhxNsGwlLe3t5o0qV5eXrFihaKjoxUWFlbpMYWFhSoqKpK/v7+kn19tvHHjRrkA6unpqZ07d1Z4juvXr2vZsmXy9fVV9+7dq1UbADR2uQXXygUUSdp6NFvPrNml3IJrDfLcjjBt/e5qzaU683aW3pStM/aBjlpyUxgqu13KkfO4Vc2lvjqWrSWpxxT7QMcKa3bGuQNoOBr8K4eS9Nhjj6lHjx6aN2+eVqxYUW7/8ePHFRkZaTMWGxur999/X5LUokULnT17VhcuXFBubq46duxYp3rOnTunL7/8Uh9//HGVx7344otq3bq1oqOjJUk+Pj6KiorS/Pnz1alTJwUGBuqTTz5Renq6wsPDbX73888/1+jRo1VYWKjg4GClpKTojjvuqPA6165d07Vr/3syz8vLkyQVFRWpqKioLlOttdLrOur6vwT02L7or/3Vpcc/5l7WjhPZ8nQtv2/HiWz9mHtZ3k1r9/dPe577dirt6z//db5ac6nOvEt/bui9KTuXPmF+WvzVoUq3b1aTedTn88Star7Zt5nZmjEw3Lrv5ppv19xvB56H7Y8e21dD6W9Nrm8xld2BpQGYOHGiLl68qOTkZG3fvl2DBw/WgQMHdPz4cT322GPWt4t26tRJkZGRSk5Otv7uTz/9pEuXLmnjxo1KSEjQxYsXdf78eQUFBemNN95QbGxsretKTEzU66+/rh9//FFNmzat8JikpCQtWLBAqamp6tatm3X8X//6lyZNmqTt27fL1dVV9957ryIiIrRv3z4dOXLEelxBQYHOnTunCxcuaPny5fr666+Vnp6uVq1albtWXFycXnnllXLjH3/8sZo1a1breQIAAABwboWFhRo7dqwuXbqk5s2bV3msU7xyKEkDBgzQQw89pLlz52rixIk2+8LDw3X06FGbsZYtW6ply5Y2Yaply5by8/PT999/X+s6jDH64IMP9NRTT1UaDF977TUlJCToq6++sgmGktS+fXulpaWpoKBAeXl5Cg4O1qhRo9SuXTub47y8vNShQwd16NBB999/v8LDw7VixQrNmTOn3PXmzJmjmTNnWrfz8vIUGhqqmJiYWy4AeykqKlJKSooefPBBubm5OaSGxo4e2xf9tb+69Pj4+Tz1XrS50v27/99QRQTW7vnPnue+nUr7Oyntsq7cqPiYm+dSnXlLcorelJ3Lusn9NWrFjkq3y6ruPOrzeeJWNZdVdn9pzbdr7rcDz8P2R4/tq6H0t/RdhdXhNOFQkhYsWKAePXooIiLCZnzMmDEaO3asNm3apOHDh1f6+y4uLho1apRWr16tefPmlfvcYUFBgdzd3av83GFaWpoyMzM1efLkCvcvWrRI8fHx2rJli3r16lXpeby8vOTl5aXc3Fxt2bKl0pvtlDLG2Lx19Gbu7u5ydy9/hzE3NzeH/4/eEGpo7OixfdFf+6tNj0P8vNU/PKjcZ9+kn2+sEeLnXev/bvY8tyNEtQ/U378/X2687FyqM29JTtGbsnNJP5Wrvh2C9I9jFW/frDbzqI/niVvVfLMhkUFKP5VrDf0313y753478Dxsf/TYvhzd35pcu2G8qbyaunbtqnHjxumtt96yGR89erSeeOIJjR49Wq+++qrS09N18uRJpaWlad26dXJ1/d8b6xMSEhQaGqo+ffroo48+0pEjR3TixAl98MEH6tGjhy5fvlxlDStWrFCfPn3UpUuXcvuSkpL05z//WR988IHuvPNOZWdnKzs72+acW7Zs0ebNm61fs/HAAw8oMjLSetfTgoICzZ07V7t27dKpU6e0b98+PfPMMzp79qzN12YAwC+Zn5e73h93v2I6BtmMl95xsS635LfnuR1h6cje1ZpLdebtLL0pW+f/bTuqGYMiFR1Z8XYpR87jVjWXio4M0oxBkfq/bUcrrNkZ5w6g4XCqVw4laf78+Vq/fr3NmMVi0bp167R8+XKtXLlSSUlJKioqUps2bTRkyBAtXrzYeqyfn5927dqlBQsWKD4+XqdOnZKfn5+6du2qRYsW2XxdRVmXLl3Shg0btGTJkgr3v/POO7p+/bqeeOIJm/F58+YpLi7Oeo45c+bo7Nmz8vf31+OPP66//OUv1kTv6uqqo0ePatWqVbpw4YICAgLUu3dv7dixQ507d65NywCgUQr189Lap/tZv8vN18NNgT71811t9jz37da6RbNqz6U683aW3pSts4Wnmz4aH2Xz3X43bzeEedyqZl8PN/l6/vw9h/+YPqTSmp1x7gAahgYdDku/uP5mYWFhunr1arlxFxcXTZkyRVOmTLnleX19fZWYmKjExMQa1ePr66vCwsJK9588efKW5xg5cqRGjhxZ6X4PDw9t3LixRnUBwC9V6atZznbu260mc6nOsc7Sm4rqDC7zN+Cy245WXzU749wBOJ5Tva0UAAAAAGAfhEMAAAAAAOEQAAAAAEA4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAABIauLoAlD/jDGSpLy8PIfVUFRUpMLCQuXl5cnNzc1hdTRm9Ni+6K/90WP7or/2R4/ti/7aHz22r4bS39JMUJoRqkI4bITy8/MlSaGhoQ6uBAAAAEBDkJ+fL19f3yqPsZjqREg4lZKSEv3444/y8fGRxWJxSA15eXkKDQ3VmTNn1Lx5c4fU0NjRY/uiv/ZHj+2L/tofPbYv+mt/9Ni+Gkp/jTHKz89XSEiIXFyq/lQhrxw2Qi4uLmrTpo2jy5AkNW/enCcbO6PH9kV/7Y8e2xf9tT96bF/01/7osX01hP7e6hXDUtyQBgAAAABAOAQAAAAAEA5hJ+7u7po3b57c3d0dXUqjRY/ti/7aHz22L/prf/TYvuiv/dFj+3LG/nJDGgAAAAAArxwCAAAAAAiHAAAAAAARDgEAAAAAIhzCTt555x21a9dOHh4e6tmzp3bs2OHokhqFuLg4WSwWm0dQUJCjy3Jq27dv18MPP6yQkBBZLBYlJyfb7DfGKC4uTiEhIfL09NSgQYN0+PBhxxTrhG7V34kTJ5Zb0/fff79jinVCiYmJ6t27t3x8fNSqVSs9+uijOnbsmM0xrOG6qU6PWce19+6776pbt27W74GLiorSl19+ad3P+q27W/WY9Vu/EhMTZbFYFBsbax1zpnVMOES9W7dunWJjY/XSSy9p//796t+/v4YNG6bTp087urRGoXPnzjp37pz1cfDgQUeX5NQKCgrUvXt3LV26tML9SUlJWrx4sZYuXardu3crKChIDz74oPLz829zpc7pVv2VpKFDh9qs6S+++OI2Vujc0tLSNHXqVO3atUspKSkqLi5WTEyMCgoKrMewhuumOj2WWMe11aZNGy1YsEB79uzRnj17NHjwYA0fPtz6D2fWb93dqscS67e+7N69W8uWLVO3bt1sxp1qHRugnt13333m2WeftRnr2LGjefHFFx1UUeMxb9480717d0eX0WhJMp9++ql1u6SkxAQFBZkFCxZYx65evWp8fX3Ne++954AKnVvZ/hpjzIQJE8zw4cMdUk9jlJOTYySZtLQ0Ywxr2B7K9tgY1nF98/PzM++//z7r145Ke2wM67e+5Ofnm/DwcJOSkmIGDhxoZsyYYYxxvudhXjlEvbp+/br27t2rmJgYm/GYmBh9++23DqqqcTlx4oRCQkLUrl07jR49Wj/88IOjS2q0srKylJ2dbbOe3d3dNXDgQNZzPUpNTVWrVq0UERGh3//+98rJyXF0SU7r0qVLkiR/f39JrGF7KNvjUqzjurtx44bWrl2rgoICRUVFsX7toGyPS7F+627q1Kn6zW9+o+joaJtxZ1vHTRxdABqXCxcu6MaNGwoMDLQZDwwMVHZ2toOqajz69Omjjz76SBERETp//rzi4+PVt29fHT58WAEBAY4ur9EpXbMVredTp045oqRGZ9iwYXryyScVFhamrKwsvfzyyxo8eLD27t3rVF8a3BAYYzRz5kz169dPXbp0kcQarm8V9VhiHdfVwYMHFRUVpatXr8rb21uffvqp7r77bus/nFm/dVdZjyXWb31Yu3at9u3bp927d5fb52zPw4RD2IXFYrHZNsaUG0PNDRs2zPpz165dFRUVpfbt22vVqlWaOXOmAytr3FjP9jNq1Cjrz126dFGvXr0UFhamv//97xoxYoQDK3M+06ZN04EDB7Rz585y+1jD9aOyHrOO6yYyMlIZGRm6ePGiNmzYoAkTJigtLc26n/Vbd5X1+O6772b91tGZM2c0Y8YMbd26VR4eHpUe5yzrmLeVol7dcccdcnV1LfcqYU5OTrm/mKDuvLy81LVrV504ccLRpTRKpXeCZT3fPsHBwQoLC2NN19Dzzz+vzz77TNu2bVObNm2s46zh+lNZjyvCOq6Zpk2bqkOHDurVq5cSExPVvXt3LVmyhPVbjyrrcUVYvzWzd+9e5eTkqGfPnmrSpImaNGmitLQ0vfnmm2rSpIl1rTrLOiYcol41bdpUPXv2VEpKis14SkqK+vbt66CqGq9r167p+++/V3BwsKNLaZTatWunoKAgm/V8/fp1paWlsZ7t5D//+Y/OnDnDmq4mY4ymTZumjRs36uuvv1a7du1s9rOG6+5WPa4I67hujDG6du0a69eOSntcEdZvzQwZMkQHDx5URkaG9dGrVy+NGzdOGRkZuuuuu5xqHfO2UtS7mTNn6qmnnlKvXr0UFRWlZcuW6fTp03r22WcdXZrTe+GFF/Twww+rbdu2ysnJUXx8vPLy8jRhwgRHl+a0Ll++rMzMTOt2VlaWMjIy5O/vr7Zt2yo2NlYJCQkKDw9XeHi4EhIS1KxZM40dO9aBVTuPqvrr7++vuLg4Pf744woODtbJkyc1d+5c3XHHHXrsscccWLXzmDp1qj7++GNt2rRJPj4+1r9M+/r6ytPT0/pdW6zh2rtVjy9fvsw6roO5c+dq2LBhCg0NVX5+vtauXavU1FRt3ryZ9VtPquox67fufHx8bD6DLP38zq6AgADruFOtYwfdJRWN3Ntvv23CwsJM06ZNzb333mtzy2/U3qhRo0xwcLBxc3MzISEhZsSIEebw4cOOLsupbdu2zUgq95gwYYIx5udbUM+bN88EBQUZd3d3M2DAAHPw4EHHFu1EqupvYWGhiYmJMS1btjRubm6mbdu2ZsKECeb06dOOLttpVNRbSWblypXWY1jDdXOrHrOO62bSpEnWfy+0bNnSDBkyxGzdutW6n/Vbd1X1mPVrHzd/lYUxzrWOLcYYczvDKAAAAACg4eEzhwAAAAAAwiEAAAAAgHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgDQoJw8eVIWi0UZGRlVHjdo0CDFxsbelprqwlnqBAAQDgEAaFBCQ0N17tw5denSRZKUmpoqi8WiixcvOrYwAECj18TRBQAAgP9xdXVVUFCQo8sAAPwC8cohAAA1UPq2z7KPQYMGSZK+/fZbDRgwQJ6engoNDdX06dNVUFBg/f0777xTCQkJmjRpknx8fNS2bVstW7as3PkzMjJ08uRJPfDAA5IkPz8/WSwWTZw40XpsSUmJZs2aJX9/fwUFBSkuLq7a81i8eLG6du0qLy8vhYaG6rnnntPly5et+z/88EO1aNFCW7ZsUadOneTt7a2hQ4fq3Llz1mOKi4s1ffp0tWjRQgEBAZo9e7YmTJigRx99tNLrXr9+XbNmzVLr1q3l5eWlPn36KDU1tdp1AwDsh3AIAEANlL7ts/Sxf/9+BQQEaMCAATp48KAeeughjRgxQgcOHNC6deu0c+dOTZs2zeYcr7/+unr16qX9+/frueee0x//+EcdPXq0wmtt2LBBknTs2DGdO3dOS5Ysse5ftWqVvLy8lJ6erqSkJL366qtKSUmp1jxcXFz05ptv6tChQ1q1apW+/vprzZo1y+aYwsJCvfbaa1q9erW2b9+u06dP64UXXrDuX7hwodasWaOVK1fqm2++UV5enpKTk6u87tNPP61vvvlGa9eu1YEDB/Tkk09q6NChOnHiRLXqBgDYkQEAALVy5coV06dPH/Pb3/7W3Lhxwzz11FPmD3/4g80xO3bsMC4uLubKlSvGGGPCwsLM7373O+v+kpIS06pVK/Puu+8aY4zJysoyksz+/fuNMcZs27bNSDK5ubk25x04cKDp16+fzVjv3r3N7NmzazWX9evXm4CAAOv2ypUrjSSTmZlpHXv77bdNYGCgdTswMNAsWrTIul1cXGzatm1rhg8fblPnjBkzjDHGZGZmGovFYv7973/bXHvIkCFmzpw5taobAFB/+MwhAAC1NHnyZOXn5yslJUUuLi7au3evMjMztWbNGusxxhiVlJQoKytLnTp1kiR169bNut9isSgoKEg5OTk1vv7N55Gk4ODgap9n27ZtSkhI0JEjR5SXl6fi4mJdvXpVBQUF8vLykiQ1a9ZM7du3r/D8ly5d0vnz53XfffdZ97u6uqpnz54qKSmp8Jr79u2TMUYRERE249euXVNAQEC16gYA2A/hEACAWoiPj9fmzZv13XffycfHR9LPnwGcMmWKpk+fXu74tm3bWn92c3Oz2WexWCoNVFWp7XlOnTqlX//613r22Wc1f/58+fv7a+fOnZo8ebKKioqqPL8xptzYzcruv1lJSYlcXV21d+9eubq62uzz9va+Zd0AAPsiHAIAUEMbNmzQq6++qi+//NLmlbV7771Xhw8fVocOHertWk2bNpUk3bhxo97OuWfPHhUXF+v111+Xi8vPtx9Yv359jc7h6+urwMBAfffdd+rfv7+1xv3796tHjx4V/s4999yjGzduKCcnx/o7AICGgxvSAABQA4cOHdL48eM1e/Zsde7cWdnZ2crOztZ///tfzZ49W//85z81depUZWRk6MSJE/rss8/0/PPP1/p6YWFhslgs+vzzz/XTTz/Z3FG0ttq3b6/i4mK99dZb+uGHH7R69Wq99957NT7P888/r8TERG3atEnHjh3TjBkzlJubW+7VxFIREREaN26cxo8fr40bNyorK0u7d+/WwoUL9cUXX9R1WgCAOiIcAgBQA3v27FFhYaHi4+MVHBxsfYwYMULdunVTWlqaTpw4of79++uee+7Ryy+/rODg4Fpfr3Xr1nrllVf04osvKjAwsNydT2ujR48eWrx4sRYuXKguXbpozZo1SkxMrPF5Zs+erTFjxmj8+PGKioqSt7e3HnroIXl4eFT6OytXrtT48eP1pz/9SZGRkXrkkUeUnp6u0NDQukwJAFAPLKaqDwcAAABUU0lJiTp16qSRI0dq/vz5ji4HAFBDfOYQAADUyqlTp7R161YNHDhQ165d09KlS5WVlaWxY8c6ujQAQC3wtlIAABqZNWvWyNvbu8JH586d6+06Li4u+vDDD9W7d2/96le/0sGDB/XVV19Zv7IDAOBceFspAACNTH5+vs6fP1/hPjc3N4WFhd3migAAzoBwCAAAAADgbaUAAAAAAMIhAAAAAECEQwAAAACACIcAAAAAABEOAQAAAAAiHAIAAAAARDgEAAAAAIhwCAAAAACQ9P8BhQO/8/KbMSUAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x1000 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "\n",
     "### 3.3.2 Target vs. zenith_angle\n",
@@ -1046,7 +1673,7 @@
     "# Add labels and title\n",
     "#plt.xlabel('Zenith Angle')\n",
     "#plt.ylabel('Target')\n",
-    "title = \"\"\"Zenith distances for of %s Observations of Different Science Program Targets on %s\"\"\" %(instrument, day_obs)\n",
+    "title = \"\"\"Zenith distances for of %s Observations of Different Science Program Targets\\n between %s and %s (inclusive)\"\"\" %(instrument, day_obs_start, day_obs_end)\n",
     "plt.title(title)\n",
     "plt.grid(True)\n"
    ]
@@ -1061,10 +1688,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "id": "1d4139ce-9cd4-47d9-8288-681db988dcc4",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.495989Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.495857Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.616007Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.615632Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.495976Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA4cAAANnCAYAAACCqS0UAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACI0UlEQVR4nOzdd3RU1cLG4XdI7yRACDXUEDqocCliQkdAUVAw0pGiIEizINK8NMECFkCkiVRRBEXpTZAiKNJBkd4REgghQMr+/uCbuUxmEhIILf6etbJg9tlzZp86887Zs4/FGGMEAAAAAPhXy3a/GwAAAAAAuP8IhwAAAAAAwiEAAAAAgHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcArc0bdo0WSwWWSwWrVmzxmG6MUbFihWTxWJRZGSk3TSLxaJXX33V9vjw4cO2eVksFrm5uSlHjhyqVKmSevXqpd27d9/lpXFu27ZtioiIUEBAgCwWi8aMGZNq3ZTL5ExCQoI+//xzVapUSUFBQfL29lZoaKiaNGmi7777zq7usWPH1LVrV4WFhcnLy0tBQUEqW7asOnXqpGPHjjmss7T+Dh8+LEk6ePCgXn31Vds8vb29Vbp0ab3zzjs6ceLEna6u2/agtsuZuLg4jRw5UhUrVpSvr698fHxUoUIFDR8+XHFxcQ7107NfPMz27NmjwYMH2/axm7Vr106FChW6523KbBk9D1j/XFxcFBgYqPLly6tLly7atGmTQ33rcTxt2jS78rlz56p06dLy8vKSxWLRH3/8IUn65JNPVKxYMbm7u8tisSgmJibzFjQTnTx5UoMHD7a1Oz327t2r1q1bq0iRIvL09FTOnDn1yCOP6NVXX9WlS5cy9PqDBw+WxWLJYKsfPDe/z1osFrm6uip//vxq3779A3duvJ9SrqfU/h7E89GsWbPSPKfgweF6vxsAPCz8/Pw0efJkhwC4du1a/f333/Lz80v3vLp3764XX3xRycnJiomJ0bZt2zRlyhR98sknGjFihF5//fVMbn3aOnTooLi4OM2ZM0eBgYF3/MbSunVrzZ8/Xz179tSQIUPk4eGhgwcPasmSJVq6dKmeffZZSdLx48f1yCOPKHv27OrTp49KlCihixcvas+ePfr666918OBBValSRRs3brSbf9euXXXx4kXNnDnTrjxPnjxatGiRXnjhBeXMmVOvvvqqKlasKIvFop07d2rKlCn68ccftW3btjtavtvxoLbLmTNnzqhOnTr6+++/1aNHD40aNUqStGrVKg0dOlSzZ8/WihUrlDt37vvc0ntnz549GjJkiCIjIx2OjwEDBui11167Pw3LRBk9Dzz33HPq06ePjDG6dOmSdu3apenTp2vixInq0aOHxo4da6ubJ08ebdy4UUWLFrWVnTt3Tq1bt1aDBg00btw4eXh4KCwsTH/88Yd69Oihjh07qm3btnJ1dc3Q+fVeOnnypIYMGaJChQqpQoUKt6y/bds2Va9eXSVLltTAgQNVqFAh/fPPP9q+fbvmzJmjvn37yt/fP92v37FjRzVo0OAOluDBMnXqVIWHhys+Pl4///yzRowYobVr12rnzp3y8fG538277xo1auTwfli1alXbsWjl4eFxr5t2S7NmzdKuXbvUs2fP+90U3IoBkKapU6caSaZjx47Gy8vLXLx40W56q1atTNWqVU3p0qVNRESE3TRJplu3brbHhw4dMpLM6NGjHV7nypUrpkGDBkaS+emnn+7KsqTG1dXVvPLKK+mqm3KZUjp48KCRZAYOHOh0elJSku3/AwcONJLMwYMHb1n3ZhEREaZ06dJOX9vHx8dUrFjRxMTEOExPTk423377baptv1se1Halpl69esbV1dWsW7fOYdq6deuMq6urqV+/vl35rfaLe+XKlSsmOTk50+c7b948I8msXr060+f9oMiM80BiYqLp0KGDkWTGjRuX5jzWr19vJJm5c+falc+YMcNIMps3b05/428hLi4u0+Z1sy1bthhJZurUqemq36ZNG+Pj42MuXbrkdPrd2HcfBtb32S1bttiVDxgwwEgyM2bMSPW5d2vb3u/XSq/MPPcmJiaaq1evZsq8UmrUqJEJDQ29K/NG5qJbKZBOUVFRkqTZs2fbyi5evKhvv/1WHTp0uOP5e3l5afLkyXJzc9Po0aNt5VeuXFHfvn1VuHBheXp6KigoSI899phdO1Kza9cuNWnSRIGBgfL09FSFChX05Zdf2qZbu6gkJiZq/Pjxti4pd+L8+fOSblwpcCZbtmx2dbNly6bg4OBb1k2PDz/8UHFxcRo3bpwCAgIcplssFjVt2tSubMqUKSpfvrxt3T777LPau3evXZ127drJ19dX+/btU/369eXj46M8efJo5MiRkqRNmzbp8ccfl4+Pj8LCwuzW8e20a/ny5WrSpIny588vT09PFStWTF26dNE///xj9zxrl7IdO3bo+eefV0BAgIKCgtS7d28lJiZq//79atCggfz8/FSoUCHbFcC0bN26VcuWLdNLL72kxx9/3GH6448/rg4dOmjp0qX67bffHKZ//vnnCgsLk4eHh0qVKqU5c+bYTU/v/rx161Y9/fTTCgoKkqenpypWrKivv/7aro51/122bJk6dOigXLlyydvbW3PnzpXFYtHKlSsd2mfdz3fs2GF7nRdeeEGFChWSl5eXChUqpKioKB05csTudZ5//nlJUs2aNW3HibWLpLNupVevXlW/fv1UuHBhubu7K1++fOrWrZtD98hChQqpcePGWrJkiR555BF5eXkpPDxcU6ZMua315sy9PA+4uLjo008/Vc6cOe3OYym7lbZr1862f7Vo0cLWLT8yMlKtWrWSJP3nP/+RxWJRu3btbPNZsWKFateuLX9/f3l7e6t69eoO29l6XPz+++967rnnFBgYaLtiaYzRuHHjVKFCBXl5eSkwMFDPPfecDh48aDePyMhIlSlTRlu2bFGNGjXk7e2tIkWKaOTIkUpOTpYkrVmzRpUqVZIktW/f3rbeBg8enOr6OX/+vPz9/eXr6+t0esr1vmTJEtWuXVsBAQHy9vZWyZIlNWLECIdlTWnu3LmqWrWqfHx85Ovrq/r16zv0TLCe1w4cOKCGDRvK19dXBQoUUJ8+fXTt2jW7uteuXdO7776rkiVLytPTUzly5FDNmjW1YcMGW530rtuMqFKliiTZjkdrm3fu3Kl69erJz89PtWvXliRduHBBXbt2Vb58+eTu7q4iRYqof//+DssSExOjl156SUFBQfL19VWjRo108OBBh22X1n6UnvOG9L9ja9WqVerUqZNy5Mghf39/tWnTRnFxcTp9+rSaN2+u7NmzK0+ePOrbt68SEhJue31JN67Id+3aVaVKlZKvr6+Cg4NVq1YtrVu3zq6e9ZgcNWqUhg4dqsKFC8vDw0OrV6+WJC1cuFDlypWTh4eHihQporFjxzrd39Kz3SMjI/Xjjz/qyJEjdt1frcaPH6/y5cvL19dXfn5+Cg8P19tvv31H6wF34D6HU+CBd/M3mq1btzaVK1e2TRs/frztW+A7vXJoVaVKFePh4WESEhKMMcZ06dLFeHt7mw8//NCsXr3aLFq0yIwcOdJ88sknabZ73759xs/PzxQtWtRMnz7d/PjjjyYqKspIMu+9954xxpizZ8+ajRs3GknmueeeMxs3bjQbN25Mc74plymly5cvm+zZs5uQkBDz+eefm0OHDqVa13qFoF69embJkiUOV2VTk9qVw7CwMJM7d+50zcMYY4YPH24kmaioKPPjjz+a6dOnmyJFipiAgADz559/2uq1bdvWuLu7m5IlS5qxY8ea5cuXm/bt2xtJpl+/fiYsLMxMnjzZLF261DRu3NhIMlu3br3tdo0fP96MGDHCfP/992bt2rXmyy+/NOXLlzclSpQw169ft9UbNGiQkWRKlChh/vvf/5rly5ebN954w0gyr776qgkPDzcff/yxXXtvdYXSuk4WL16cap2ffvrJSDIjRoywlUkyBQoUMKVKlTKzZ88233//ve1K+Lx582z10rM/r1q1yri7u5saNWqYuXPnmiVLlph27do5XKGxHpv58uUznTt3NosXLzbffPONuXr1qgkODjYtW7Z0aHvlypXNI488Yns8b948M3DgQPPdd9+ZtWvXmjlz5piIiAiTK1cuc+7cOWPMjePEul4+++wz23Fy9uxZY8yN/ePmb8STk5NN/fr1jaurqxkwYIBZtmyZef/9921Xj2/+Zj40NNTkz5/flCpVykyfPt0sXbrUPP/880aSWbt2bYbWmzP36zzwwgsvGEnm2LFjxpj/nfus2+/AgQPms88+M5LM8OHDzcaNG83u3bvN7t27zTvvvGOru3HjRnPgwAFjjDFfffWVsVgs5plnnjHz5883P/zwg2ncuLFxcXExK1assL229bgIDQ01b775plm+fLlZsGCBMcaYTp06GTc3N9OnTx+zZMkSM2vWLBMeHm5y585tTp8+bZtHRESEyZEjhylevLiZMGGCWb58uenatauRZL788ktjjDEXL1607YPvvPOObb1Zl9mZoUOH2s45a9asMVeuXEm17qRJk4zFYjGRkZFm1qxZZsWKFWbcuHGma9euDst6s2HDhhmLxWI6dOhgFi1aZObPn2+qVq1qfHx8zO7du231bj6vvf/++2bFihVm4MCBxmKxmCFDhtjqJSQkmJo1axpXV1fTt29f89NPP5nvv//evP3222b27Nm2euldt86kduVw7NixRpKZOHGirc1ubm6mUKFCZsSIEWblypVm6dKlJj4+3pQrV874+PiY999/3yxbtswMGDDAuLq6moYNG9rml5SUZB5//HHj6elpRo4caZYtW2aGDBliihcvbiSZQYMGOaxbZ/tRes4bNy9X4cKFTZ8+fcyyZcvMe++9Z1xcXExUVJR55JFHzNChQ83y5cvNm2++aSSZDz74IM11lVLKY3Hfvn3mlVdeMXPmzDFr1qwxixYtMi+99JLJli2bXc8H6zGZL18+U7NmTfPNN9+YZcuWmUOHDpnFixebbNmymcjISPPdd9+ZefPmmf/85z+mUKFCDvtberb77t27TfXq1U1ISIjtOLGeY2bPnm0kme7du5tly5aZFStWmAkTJpgePXpkaD0g8xAOgVu4+U1r9erVRpLZtWuXMcaYSpUqmXbt2hljTKaFwxYtWhhJ5syZM8YYY8qUKWOeeeaZDLf7hRdeMB4eHubo0aN25U8++aTx9va26954qw96N0tP3R9//NHkzJnTSDKSTI4cOczzzz9vvv/+e7t6ycnJpkuXLiZbtmxGkrFYLKZkyZKmV69eaYbK1MKhp6enqVKlSrqWIzo62nh5edl9cDDGmKNHjxoPDw/z4osv2sratm3rEKwSEhJMrly5jCTz+++/28rPnz9vXFxcTO/evW+rXSklJyebhIQEc+TIESPJLFy40DbN+uEl5YeJChUqGElm/vz5Du1t2rRpmq/38ssvG0lm3759qdbZu3evkWTXBVGS8fLysvsQmJiYaMLDw02xYsVsZenZn8PDw03FihVtX5BYNW7c2OTJk8fW3dh6bLZp08ZhHr179zZeXl52+/mePXuMpDQDVWJiorl8+bLx8fExY8eOtZWn1a00ZThcsmSJkWRGjRplV2/u3Ll2H3SNuREOPT09zZEjR2xl8fHxJigoyHTp0sVW9rCdB6wfdK1dQ1OGQ2OM7Xx685cHxjgPCnFxcSYoKMg89dRTdnWTkpJM+fLl7b60sx4XKbu2WwNwyuPl2LFjxsvLy7zxxhu2soiICKddW0uVKmXXpTqj3UqvXr1qnnnmGdu50cXFxVSsWNH079/f9mWDMcbExsYaf39/8/jjj6fZ1TRlODx69KhxdXU13bt3t6sXGxtrQkJCTPPmzW1l1vPa119/bVe3YcOGpkSJErbH06dPN5LMF198kWo7MrJunbFu802bNpmEhAQTGxtrFi1aZHLlymX8/Pxs5xVrm6dMmWL3/AkTJjhdlvfee89IMsuWLTPG3HhvkmTGjx9vV2/EiBGphsPUfiJxs9TOG9blSrk9rPvAhx9+aFdeoUIFuy+v0uNWx2JiYqJJSEgwtWvXNs8++6yt3HpMFi1a1O5LR2NufLYpUKCAuXbtmq0sNjbW5MiRw25/y8h2T61b6auvvmqyZ8+e7uXF3Ue3UiADIiIiVLRoUU2ZMkU7d+7Uli1bMqVL6c2MMXaPK1eurMWLF+utt97SmjVrFB8fn675rFq1SrVr11aBAgXsytu1a6crV644/Kg9MzVs2FBHjx7Vd999p759+6p06dJasGCBnn76absRLS0WiyZMmKCDBw9q3Lhxat++vRISEvTRRx+pdOnSWrt27V1r48aNGxUfH2/XZU2SChQooFq1ajl0VbNYLGrYsKHtsaurq4oVK6Y8efKoYsWKtvKgoCAFBwc7dC/KiLNnz+rll19WgQIF5OrqKjc3N4WGhkqSQ5dXSWrcuLHd45IlS8pisejJJ590aO+dtMvKuo+m7F5Uu3Ztu0FqXFxc1KJFCx04cEDHjx+XdOv9+cCBA9q3b59atmwpSUpMTLT9NWzYUKdOndL+/fvtntOsWTOHNnbo0EHx8fGaO3eurWzq1Kny8PDQiy++aCu7fPmy3nzzTRUrVkyurq5ydXWVr6+v4uLinK7r9Fi1apUkOexbzz//vHx8fBz2rQoVKqhgwYK2x56engoLC7PbVg/beSDleexObdiwQRcuXFDbtm3t9onk5GQ1aNBAW7ZscRhFN+V+sWjRIlksFrVq1cpuHiEhISpfvrzDaNQhISGqXLmyXVm5cuXu6Bjy8PDQd999pz179uijjz7SCy+8oHPnzmnYsGEqWbKkbd/esGGDLl26pK5du2aoi+/SpUuVmJioNm3a2C2jp6enIiIiHJbRYrHoqaeeSnMZFy9eLE9PzzTf6zK6blNTpUoVubm5yc/PT40bN1ZISIgWL17sMPhVym27atUq+fj46LnnnrMrtx6D1mPO+p7SvHlzu3rWn4044+z8ktHzhrNztHRjgJmU5Zlxjp4wYYIeeeQReXp62t5DVq5c6bRtTz/9tNzc3GyP4+LitHXrVj3zzDNyd3e3lfv6+jrsK5mx3StXrqyYmBhFRUVp4cKFDj+fwL3HaKVABlgsFrVv314ff/yxrl69qrCwMNWoUSNTX+PIkSPy8PBQUFCQJOnjjz9W/vz5NXfuXL333nvy9PRU/fr1NXr0aBUvXjzV+Zw/f97p7/7y5s1rm343eXl56ZlnntEzzzwjSTp69KiefPJJffbZZ3rllVdUunRpW93Q0FC98sortsdff/21oqKi9Prrr+vXX39N92sWLFhQhw4dSlfdtH4bmTdvXi1fvtyuzNvbW56ennZl7u7utu2Usvzq1au31a7k5GTVq1dPJ0+e1IABA1S2bFn5+PgoOTlZVapUcRoKUrbB3d091fbeaqh8a0g5dOiQSpQo4bSO9XYOKQNHSEiIQ11r2fnz55U/f/5b7s9nzpyRJPXt21d9+/Z1+vopPzw424alS5dWpUqVNHXqVHXu3FlJSUmaMWOGmjRpYre+XnzxRa1cuVIDBgxQpUqV5O/vb/siIL0BLKXz58/L1dVVuXLlsiu3WCwKCQlxOPZy5MjhMA8PDw+713/YzgPWD7jW17lT1v0i5Yf/m124cMFuRMuUy33mzBkZY1IdZbdIkSJ2j9OzXW5XyZIlbQHBGKMxY8aod+/eGjBggL7++mudO3dOkpQ/f/4Mzde6nqy/hUwp5e+4nZ0nPDw87M5f586dU968edP8DXhG121qpk+frpIlS8rV1VW5c+d2uu96e3s7jOh6/vx5hYSEOATp4OBgubq62vZz67GZ8pyZ1sjLztqQ0fOGs3N0auU3r/vb8eGHH6pPnz56+eWX9d///lc5c+aUi4uLBgwY4DQcply+6OjoVLdlyrLM2O6tW7dWYmKivvjiCzVr1kzJycmqVKmShg4dqrp1697y+ch8hEMgg9q1a6eBAwdqwoQJGjZsWKbO+8SJE/rtt98UEREhV9cbh6ePj4+GDBmiIUOG6MyZM7arB0899ZT27duX6rxy5MihU6dOOZSfPHlSkpQzZ85MbfutFCxYUJ07d1bPnj21e/duu3CYUvPmzTVixAjt2rUrQ69Rv359ffLJJ9q0aZNtIIPUWD/4pbaOMnP9ZKRdu3bt0vbt2zVt2jS1bdvWVn7gwIFMa09a6tatq7ffflsLFixIdYj8BQsW2Ore7PTp0w51rWXW9X2r/dm63vv16+cweJBVytCa2pWV9u3bq2vXrtq7d68OHjyoU6dOqX379rbpFy9e1KJFizRo0CC99dZbtvJr167pwoULTueZHjly5FBiYqLOnTtnFxCNMTp9+nSqH9zT8jCdB+Lj47VixQoVLVo0w+EmNdZ2fvLJJ6keQyk/oKbcL3LmzCmLxaJ169Y5Her/fg3/b7FY1KtXL7377ru2c551v7FecU8v63r65ptvbL0N7lSuXLm0fv16JScnpxoQM2vdlixZUo899liadZwd7zly5NDmzZtljLGbfvbsWSUmJtrWi/XYvHDhgl0wc3buSu317tZ5I7PMmDFDkZGRGj9+vF15bGys0/oply8wMFAWi8X2RcPNUq6nzNru7du3V/v27RUXF6eff/5ZgwYNUuPGjfXnn39m2n6M9KNbKZBB+fLl0+uvv66nnnrK7sP7nYqPj1fHjh2VmJioN954w2md3Llzq127doqKitL+/ft15cqVVOdXu3ZtrVq1yvYh0Gr69Ony9va+ZUi5XbGxsbp8+bLTadZvLa1XE5x9aJVudNk5duxYhq869OrVSz4+Prb7IKZkjNF3330n6ca9oby8vDRjxgy7OsePH7d1xcssGWmX9Y065Zvq559/nmntSctjjz2mevXqafLkyfrll18cpq9fv15TpkxRgwYN9Oijj9pNW7lypd0HiqSkJM2dOzfVkOBsfy5RooSKFy+u7du367HHHnP6l9573kVFRcnT01PTpk3TtGnTlC9fPtWrV8823WKxyBjjsK4nTZqkpKQkuzJrnfRcNbLuOyn3rW+//VZxcXF3vG89yOeBpKQkvfrqqzp//rzefPPNTJtv9erVlT17du3ZsyfV/eLmLnDONG7cWMYYnThxwunzy5Ytm+F2ZWS/kFI/5508eVKXLl2ynfOqVaumgIAATZgwIUNddOvXry9XV1f9/fffqa6njHryySd19epV20izztyNdZsRtWvX1uXLl21fXFlNnz7dNl268dMQSXbdzSU5jKqcloycN+4Hi8Xi0LYdO3akuwu5j4+PHnvsMS1YsEDXr1+3lV++fFmLFi2yq5uR7Z6eq+4+Pj568skn1b9/f12/fl27d+9OV5uRubhyCNwG6y0M0sPZt5xHjx7Vpk2blJycrIsXL2rbtm2aMmWKjhw5og8++MDuA+x//vMfNW7cWOXKlVNgYKD27t2rr776SlWrVpW3t3eqrzto0CAtWrRINWvW1MCBAxUUFKSZM2fqxx9/1KhRo5zeUiG9/v77b33zzTcO5aVKldKVK1dUv359vfDCC4qIiFCePHkUHR2tH3/8URMnTlRkZKSqVasmSRo2bJh++eUXtWjRwjYM9qFDh/Tpp5/q/PnzdkPhp0fhwoU1Z84c2/ysN5uXbtzEfMqUKTLG6Nlnn1X27Nk1YMAAvf3222rTpo2ioqJ0/vx5DRkyRJ6enho0aNBtr587aVd4eLiKFi2qt956S8YYBQUF6YcffnDo5no3TZ8+XXXq1FG9evXUo0cP2werVatWaezYsQoPD3f6QTFnzpyqVauWBgwYIB8fH40bN0779u2z++CVnv35888/15NPPqn69eurXbt2ypcvny5cuKC9e/fq999/17x589K1HNmzZ9ezzz6radOmKSYmRn379rW78uHv768nnnhCo0ePVs6cOVWoUCGtXbtWkydPVvbs2e3mVaZMGUnSxIkT5efnJ09PTxUuXNhp18O6deuqfv36evPNN3Xp0iVVr15dO3bs0KBBg1SxYkW1bt06Xe2/2YN4Hjhz5ow2bdokY4xiY2O1a9cuTZ8+Xdu3b1evXr3UqVOn2553Sr6+vvrkk0/Utm1bXbhwQc8995yCg4N17tw5bd++XefOnXO4UpJS9erV1blzZ7Vv315bt27VE088IR8fH506dUrr169X2bJl7bq3p0fRokXl5eWlmTNnqmTJkvL19VXevHlT/WKrc+fOiomJUbNmzVSmTBm5uLho3759+uijj5QtWzZboPb19dUHH3ygjh07qk6dOurUqZNy586tAwcOaPv27fr000+dzr9QoUJ699131b9/fx08eFANGjRQYGCgzpw5o19//dV2BTojoqKiNHXqVL388svav3+/atasqeTkZG3evFklS5bUCy+8cFfWbUa0adNGn332mdq2bavDhw+rbNmyWr9+vYYPH66GDRuqTp06kqQGDRqoevXq6tOnjy5duqRHH31UGzdutIXI9Nw+KSPnjfuhcePG+u9//6tBgwYpIiJC+/fv17vvvqvChQsrMTExXfN499131ahRI9WvX1+vvfaakpKSNHr0aPn6+tpdHc3Idi9btqzmz5+v8ePH69FHH1W2bNn02GOPqVOnTvLy8lL16tWVJ08enT59WiNGjFBAQMBt9bJAJriXo98AD6PUhthOKeVopXFxcUaS6dOnj63MOjqYbhqpLjAw0Dz66KOmZ8+edsOMW7311lvmscceM4GBgcbDw8MUKVLE9OrVy/zzzz+3bPvOnTvNU089ZQICAoy7u7spX76801H1lMFRClP7GzRokImOjjZDhw41tWrVMvny5TPu7u7Gx8fHVKhQwQwdOtRu6PZNmzaZbt26mfLly5ugoCDj4uJicuXKZRo0aGB++umnVNuQ2milVn///bfp2rWrKVasmPHw8DBeXl6mVKlSpnfv3g6joE6aNMmUK1fOuLu7m4CAANOkSROH7dC2bVvj4+OT7naEhoaaRo0a3Xa79uzZY+rWrWv8/PxMYGCgef75583Ro0dTHU3v5qHTb6e9zly+fNkMHz7cVKhQwXh7extvb29Trlw5M3ToUHP58mWH+tZ9aNy4caZo0aLGzc3NhIeHm5kzZ9rVS+/+vH37dtO8eXMTHBxs3NzcTEhIiKlVq5aZMGGCrU56js1ly5bZ9s+bb09idfz4cdOsWTMTGBho/Pz8TIMGDcyuXbtMaGioadu2rV3dMWPGmMKFCxsXFxe7ESpTjlZqzI0RR998800TGhpq3NzcTJ48ecwrr7xioqOj7eqltq9ERETYnU8e5PNAtmzZjL+/vylbtqzp3Lmz09tg3OlopVZr1641jRo1MkFBQcbNzc3ky5fPNGrUyG4eqR0XVlOmTDH/+c9/jI+Pj/Hy8jJFixY1bdq0sbv9TGrHirNtPXv2bBMeHm7c3NwcjtGUli5dajp06GBKlSplAgICjKurq8mTJ49p2rSp0/X2008/mYiICOPj42O8vb1NqVKlbLcguXlZU1qwYIGpWbOm8ff3Nx4eHiY0NNQ899xzdrf8SO084Wye8fHxZuDAgaZ48eLG3d3d5MiRw9SqVcts2LDBrl561q0z6X2fTa3NxtwYKfrll182efLkMa6uriY0NNT069fP4abuFy5cMO3btzfZs2c33t7epm7dumbTpk1Gkt1Io2ntR+k9b6S2XBk9d6cl5XF77do107dvX5MvXz7j6elpHnnkEbNgwQKHffdWo6d/9913pmzZssbd3d0ULFjQjBw50vTo0cMEBgY61E3Pdr9w4YJ57rnnTPbs2Y3FYrHtY19++aWpWbOmyZ07t3F3dzd58+Y1zZs3Nzt27MjQekDmsRiTyUOKAZAkbdu2TY888og+++wzde3a9X43BwAAODFr1iy1bNlSv/zyi61nC+wlJCSoQoUKypcvn5YtW3a/m4O7iG6lQCY7fvy4/vjjDw0bNkze3t620ToBAMD9NXv2bJ04cUJly5ZVtmzZtGnTJo0ePVpPPPEEwfAmL730kurWrWvr6jlhwgTt3btXY8eOvd9Nw11GOAQy2aRJkzRy5EiVK1dO33//faYN5Q4AAO6Mn5+f5syZo6FDhyouLk558uRRu3btNHTo0PvdtAdKbGys+vbtq3PnzsnNzU2PPPKIfvrpJ9vvN5F10a0UAAAAAMCtLAAAAAAAhEMAAAAAgAiHAP6l1qxZI4vF4vR+jbdrz549Gjx4sA4fPpxp83yQJCUl6cMPP1SDBg2UP39+eXt7q2TJknrrrbcUExPj9DmffPKJwsPD5eHhocKFC2vIkCFKSEiwqzN//nxFRUWpWLFi8vLyUqFChdSyZUv99ddfabYnPj5eYWFhslgsev/99x2mv/POO2rcuLHy5csni8Widu3apTqvgwcPqmnTpsqePbt8fX1Vt25d/f7773Z1Tp06pXfeeUdVq1ZVzpw55e/vr0cffVQTJ0685c2vJ02aJIvFIl9f3zTr3Q+FChVKc91IGV/2y5cvq2fPnsqbN688PT1VoUIFhxuN387+ZLVnzx55eHjIYrFo69atdtOOHz+unj17KiIiQtmzZ5fFYknzBu4rVqyw3S8yZ86cateunc6ePWtX57ffflO3bt1UtmxZ+fn5KXfu3KpTp45WrVrldJ7ffvutqlevrqCgIGXPnl2VK1fWV199leYy3SwhIUHh4eF299SdNm2aLBbLXT2/WCwWDR48+KGd/59//il3d3eHYxdA+hEOASCT7NmzR0OGDMmy4TA+Pl6DBw9WaGioxowZo59++kmdOnXSxIkTVb16dcXHx9vVHzZsmF577TU1bdpUS5cuVdeuXTV8+HB169bNrt57772nK1euqH///lqyZImGDh1quxXM7t27U23PgAEDFBcXl+r0jz76SOfPn9fTTz8td3f3VOudO3dONWrU0J9//qkpU6bo66+/1tWrVxUZGan9+/fb6v3222+aPn26ateurenTp+vbb79VRESEXnnllTRv+H7ixAn17dv3oR6cKqPL3rRpU3355ZcaNGiQFi9erEqVKikqKkqzZs2y1cno/mSVlJSkDh06KGfOnE6nHzhwQDNnzpS7u7saNmyY5nKtXbtWTz75pHLnzq2FCxdq7NixWrFihWrXrq1r167Z6s2ePVu//vqrOnTooIULF2rSpEny8PCwrY+bTZkyRc8995zy5MmjmTNnas6cOSpatKjatGmjjz76KM32WI0bN07R0dHq3r27raxRo0bauHGj8uTJk655PIg2btyojh073rX5h4WFqWXLlurVq9ddew0gy7u/t1kEgPsjtRtw34l58+YZSWb16tWZNs8HSWJiotObrluX+6uvvrKV/fPPP8bT09N07tzZru6wYcOMxWIxu3fvtpWdOXPGYZ4nTpwwbm5u5qWXXnLals2bNxt3d3fbazu7kXNSUpLt/z4+Pg43tbd6/fXXjZubmzl8+LCt7OLFiyZnzpymefPmtrILFy6Y69evOzy/W7duRpI5evSo0/k3btzYPPXUU7d1g+t7IeWNu53JyLL/+OOPRpKZNWuWXd26deuavHnzmsTERGNMxvanm40ePdrky5fPjB071ukNxm/e7lu2bDGSzNSpU53Oq1KlSqZUqVImISHBVvbLL78YSWbcuHG2Mmf7aGJioilXrpwpWrSoXXn16tVNaGioXTuSk5NNeHi4KVeunNN23CwhIcHky5fPvPXWW7esm9kkmUGDBt3z181MW7duNZLML7/8cr+bAjyUuHII4F/t6tWr6t27t0JCQuTl5aWIiAht27bNod7WrVv19NNPKygoSJ6enqpYsaK+/vpr2/Rp06bp+eeflyTVrFlTFovF1p3ts88+U7Zs2ey6qn3wwQeyWCx2V9GSk5MVGBioPn362MquX7+uoUOH2rpm5sqVS+3bt9e5c+cc2jh37lxVrVpVPj4+8vX1Vf369R2WpV27dvL19dWBAwfUsGFD+fr6qkCBAurTp4/dlRJnXFxclCNHDofyypUrS5KOHTtmK1uyZImuXr2q9u3b29Vt3769jDFasGCBrSw4ONhhnnnz5lX+/Pnt5nnzOunQoYO6deumxx57LNX2ZsuWvre47777TrVq1VJoaKitzN/fX02bNtUPP/ygxMRESVJgYKDc3Nwcnm9d/uPHjztMmzFjhtauXatx48alqy1WW7du1QsvvKBChQrZutpGRUXpyJEjdvWsXQ1Xr16tV155RTlz5lSOHDnUtGlTnTx50q5uQkKC3njjDYWEhMjb21uPP/64fv3113S1JyPL/t1338nX19d2PFi1b99eJ0+e1ObNmyVlbH+y+uuvvzRw4ECNGzdO/v7+Ttua3u1+4sQJbdmyRa1bt5ar6//u7FWtWjWFhYXpu+++s5U520ddXFz06KOPOrTTzc1Nvr6+du2wWCzy9/eXp6fnLdv1/fff68SJE2rdurVdubNupZGRkSpTpoy2bNmiGjVqyNvbW0WKFNHIkSOVnJxs9/yYmBj16dNHRYoUkYeHh4KDg9WwYUPt27cv1bYMHjxYFovFodxZW1atWqXIyEjlyJFDXl5eKliwoJo1a6YrV67YrQdrt9Lt27fLYrFo8uTJDvNfvHixLBaLvv/+e1vZX3/9pRdffFHBwcHy8PBQyZIl9dlnnzk899FHH1XJkiU1YcKEVJcLQOoIhwD+1d5++20dPHhQkyZN0qRJk3Ty5ElFRkbq4MGDtjqrV69W9erVFRMTowkTJmjhwoWqUKGCWrRoYfstU6NGjTR8+HBJ0meffaaNGzdq48aNatSokerUqSNjjFauXGmb54oVK+Tl5aXly5fbyrZu3aqYmBjbfaSSk5PVpEkTjRw5Ui+++KJ+/PFHjRw5UsuXL1dkZKRdt7vhw4crKipKpUqV0tdff62vvvpKsbGxqlGjhvbs2WO3zAkJCXr66adVu3ZtLVy4UB06dNBHH32k995777bWofV3V6VLl7aV7dq1S5JUtmxZu7p58uRRzpw5bdNTc/DgQR05csRunlbvvvuu4uLi9N///ve22nuz+Ph4/f333ypXrpzDtHLlyik+Pt5uX3Bm1apVcnV1VVhYmF352bNn1bNnT40cOVL58+fPULsOHz6sEiVKaMyYMVq6dKnee+89nTp1SpUqVdI///zjUL9jx45yc3PTrFmzNGrUKK1Zs0atWrWyq9OpUye9//77atOmjRYuXKhmzZqpadOmio6OzlDbbuZs2Xft2qWSJUvaBS5JtnV8q23vbH+SJGOMOnbsqMaNG+vpp5++7Tbf3M6b25WyrbdqZ2JiotatW+fQzu7du2vv3r0aNmyYzp07p3/++Ufvv/++fvvtN/Xt2/eW7frxxx8VHBysUqVKpWs5Tp8+rZYtW6pVq1b6/vvv9eSTT6pfv36aMWOGrU5sbKwef/xxff7552rfvr1++OEHTZgwQWFhYTp16lS6Xicthw8fVqNGjeTu7q4pU6ZoyZIlGjlypHx8fHT9+nWnzylfvrwqVqyoqVOnOkybNm2aLbxKN7rsV6pUSbt27dIHH3ygRYsWqVGjRurRo4eGDBni8PzIyEgtXrxYhru1ARl3fy9cAsD9Ye1W+sgjj5jk5GRb+eHDh42bm5vp2LGjrSw8PNxUrFjRruuZMTe6C+bJk8fWfSytbqX58+c3HTp0MMYYc+3aNePj42PefPNNI8kcOXLEGHOjy6Wbm5u5fPmyMcaY2bNnG0nm22+/tZuXtauctdvb0aNHjaurq+nevbtdvdjYWBMSEmLXNbJt27ZGkvn666/t6jZs2NCUKFHi1isuhePHj5vcuXObxx57zK4bXadOnYyHh4fT54SFhZl69eqlOs+EhAQTGRlp/P39Hbpqbtu2zbi5uZklS5YYY4w5dOhQqt1Kb5Zat9ITJ04YSWbEiBEO02bNmmUkmQ0bNqQ636VLl5ps2bKZXr16OUxr1qyZqVatmm3/upNupYmJieby5cvGx8fHjB071lY+depUI8l07drVrv6oUaOMJHPq1CljjDF79+41khzaOXPmTCPplt1KnUlt2YsXL27q16/vUP/kyZNGkhk+fHiq80xtfzLGmE8++cQEBgaa06dPG2P+t+wpu5XeLK1updZl37hxo8O0zp07G3d391Tna4wx/fv3N5LMggULHKYtWLDABAQEGElGkvHy8jIzZsxIc35WJUuWNA0aNHAoty7voUOHbGURERFGktm8ebNd3VKlStltg3fffddIMsuXL0/ztZWiW+mgQYOMs4+KKdvyzTffGEnmjz/+yND8P/74YyPJ7N+/31Z24cIF4+HhYfr06WMrq1+/vsmfP7+5ePGi3fxeffVV4+npaS5cuGBX/sUXXxhJZu/evWm2B4AjrhwC+Fd78cUX7bpNhYaGqlq1alq9erWkG4Nb7Nu3Ty1btpR042qB9a9hw4Y6deqU3aAlqaldu7ZWrFghSdqwYYOuXLmi3r17K2fOnLarh9ZRE318fCRJixYtUvbs2fXUU0/ZvW6FChUUEhKiNWvWSJKWLl2qxMREtWnTxq6ep6enIiIibPWsLBaLnnrqKbuycuXKOXRZvJULFy6oYcOGMsZo7ty5Dt35nHVHu9U0Y4xeeuklrVu3TtOnT1eBAgVs0xITE9WhQwe1aNFC9evXz1Bbb+V22vr777+refPmqlKlikaMGGE37dtvv9UPP/ygL774Is15p+by5ct68803VaxYMbm6usrV1VW+vr6Ki4vT3r17HeqnvJJmvRpm3abW/dm6H1s1b97c4QpfeqS17NLtrc+09qcjR46oX79+Gj16tHLnzp3h9qYltfaktQyTJk3SsGHD1KdPHzVp0sRu2pIlS9SqVSs1bdpUixcv1vLly9WxY0e1a9fO6VWylE6ePOm0G2tqQkJCbF1xrVIez4sXL1ZYWJitV0Jmq1Chgtzd3dW5c2d9+eWXt7zabtWyZUt5eHjYjSY7e/ZsXbt2zdYl/erVq1q5cqWeffZZeXt7O5yDr169qk2bNtnN17r+Tpw4kTkLCPyLEA4B/KuFhIQ4LTt//rwk6cyZM5Kkvn37ys3Nze6va9eukuS0m19KderU0dGjR/XXX39pxYoVqlixooKDg1WrVi2tWLFC8fHx2rBhg92HtzNnzigmJkbu7u4Or3369Gnb61rbWKlSJYd6c+fOdWift7e3w2+fPDw8dPXq1fSuNkVHR6tu3bo6ceKEli9friJFithNz5Ejh65evWr3eyOrCxcuKCgoyKHc/H+3wRkzZmjatGkOH7rHjBmjgwcPatCgQYqJiVFMTIwuXbok6cYHyJiYmFveUiKlwMBAWSwW2/ZO2U5JTtu6bds21a1bV8WLF9dPP/0kDw8P27TLly+rW7du6t69u/LmzWtrq7V7XUxMTJqjrEo3vrT49NNP1bFjRy1dulS//vqrtmzZoly5cjkdxTPlb/es7bHWtS5fyv3d1dXV6e/+0pLWslvbktH1eav9qVu3bipTpoyaNWtmW5/Wfevy5cu6ePFihpbB2k5JqbbVWTslaerUqerSpYs6d+6s0aNH200zxqhDhw564oknNGXKFDVo0EB16tTRxx9/rBdffFHdu3e/5baPj49P128TUy7HzTw8POz2k3PnzmW4a3NGFC1aVCtWrFBwcLC6deumokWLqmjRoho7dmyazwsKCtLTTz+t6dOn247dadOmqXLlyrbuuufPn1diYqI++eQTh/ObtdtpynOcdf2lNuItgNRl/OtCAMhCTp8+7bTM+oHLOlx+v3791LRpU6fzKFGixC1fp3bt2pJuXB1cvny56tatayt/55139PPPP+vatWt24dA6uMiSJUucztPPz8+ujd98843doCp3S3R0tOrUqaNDhw5p5cqVTn+zZf2t4c6dO/Wf//zHVm4NtWXKlLGrbw2GU6dO1eTJkx1+Lyfd+I3YxYsXVbx4cYdpAwYM0IABA7Rt2zZVqFAh3cvi5eWlYsWKaefOnQ7Tdu7cKS8vL4egsm3bNtWpU0ehoaFatmyZAgIC7Kb/888/OnPmjD744AN98MEHDvMNDAxUkyZN7AbludnFixe1aNEiDRo0SG+99Zat/Nq1a7aAlVHW/fn06dPKly+frTwxMdFpOErNrZZdurHtZ8+ercTERLurktZ1nHLbp2d/2rVrl44cOaLAwECHaTVr1lRAQMAt742YkrUdO3fudLjlxc6dOx3aKd0Ihh07dlTbtm01YcIEh6uLZ86c0alTp9SlSxeH51aqVEnTp0/X4cOHnf6W1ipnzpy3vZ1TkytXLqcDJt2KNWRdu3bN7ksAZ1+I1ahRQzVq1FBSUpK2bt2qTz75RD179lTu3Ln1wgsvpPoa7du317x587R8+XIVLFhQW7Zs0fjx423TAwMD5eLiotatWzvcBseqcOHCdo+t6y+1250ASB3hEMC/2uzZs9W7d2/bh7wjR45ow4YNatOmjaQbwa948eLavn27bcCZ1KS8WnOzPHnyqFSpUvr222/122+/2eZVt25ddenSRR9++KH8/f1VqVIl23MaN26sOXPmKCkpyS5gpVS/fn25urrq77//VrNmzTK2AjLI+kH+4MGDWr58uSpWrOi0XoMGDeTp6alp06bZtd06yuEzzzxjKzPGqFOnTpo6daptwAxn3nrrLYebtZ8+fVpRUVF6+eWX1aJFCxUrVizDy/Tss89qzJgxOnbsmK0ba2xsrObPn6+nn37aLuD88ccfqlOnjvLnz6/ly5c7DSshISG2bpw3GzlypNauXavFixen+aHVYrHIGONwRW7SpEkZvjJqFRkZKUmaOXOmHn30UVv5119/bRuN9VbSs+zSjfX5xRdf6Ntvv1WLFi1s5V9++aXy5s1rtz+kd3+aM2eOw5XtJUuW6L333tOECRPSDFupyZcvnypXrqwZM2aob9++cnFxkSRt2rRJ+/fvV8+ePe3qT5s2TR07dlSrVq00adIkp91OAwMD5enp6dDNUbpxj79s2bLd8j6F4eHh+vvvvzO8PGl58sknNXDgQK1atUq1atVK9/MKFSokSdqxY4fduemHH35I9TkuLi76z3/+o/DwcM2cOVO///57muGwXr16ypcvn6ZOnaqCBQvK09NTUVFRtune3t6qWbOmtm3bpnLlyqV5z1KrgwcPKlu2bOn64g6APcIhgH+1s2fP6tlnn1WnTp108eJFDRo0SJ6enurXr5+tzueff64nn3xS9evXV7t27ZQvXz5duHBBe/fu1e+//6558+ZJ+t+ViIkTJ8rPz0+enp4qXLiw7apN7dq19cknn8jLy0vVq1eXdOMb78KFC2vZsmUOQeSFF17QzJkz1bBhQ7322muqXLmy3NzcdPz4ca1evVpNmjTRs88+q0KFCundd99V//79dfDgQTVo0ECBgYE6c+aMfv31V/n4+Dgd0S+j4uPjbbfHGDNmjBITE+0+BOfKlUtFixaVdKO72DvvvKMBAwYoKChI9erV05YtWzR48GB17NjRbiTGHj16aPLkyerQoYPKli1rN08PDw9bYAgPD1d4eLhdm6xD6RctWtQWgKzWrl1ru+VHUlKSjhw5om+++UaSFBERoVy5ckm60WX4q6++UqNGjfTuu+/Kw8NDI0eO1NWrV23D7kvS/v37bVd2hw0bpr/++kt//fWXbXrRokWVK1cueXp6OrRFuhEuXFxcnE67mb+/v5544gmNHj1aOXPmVKFChbR27VpNnjxZ2bNnT/O5qSlZsqRatWqlMWPGyM3NTXXq1NGuXbv0/vvvp3pLiJuld9mlG0Gkbt26euWVV3Tp0iUVK1ZMs2fP1pIlSzRjxgxbCMvI/lSlShWHNlm3/aOPPupwSxPrdrb+9m3r1q3y9fWVJD333HO2eu+9957q1q2r559/Xl27dtXZs2f11ltvqUyZMnZfUsybN08vvfSSKlSooC5dujjcAqRixYry8PCQh4eHunbtqg8//FBt2rRRixYt5OLiogULFmjWrFl66aWXUu2uahUZGal3331XV65ckbe3d5p106tnz56aO3eumjRporfeekuVK1dWfHy81q5dq8aNG6tmzZpOn9ewYUMFBQXppZde0rvvvitXV1dNmzbN4fYdEyZM0KpVq9SoUSMVLFhQV69e1ZQpUyTplr9zdHFxUZs2bWxfkDVt2tThivTYsWP1+OOPq0aNGnrllVdUqFAhxcbG6sCBA/rhhx9sI9xabdq0SRUqVEj1CwwAabh/Y+EAwP1jHa30q6++Mj169DC5cuUyHh4epkaNGmbr1q0O9bdv326aN29ugoODjZubmwkJCTG1atUyEyZMsKs3ZswYU7hwYePi4uIwSuLChQuNJFO3bl2753Tq1MlIMh9//LHD6yYkJJj333/flC9f3nh6ehpfX18THh5uunTpYv766y+7ugsWLDA1a9Y0/v7+xsPDw4SGhprnnnvOrFixwlYntREzUxuV8GbWkUFT+3M24uXYsWNNWFiYcXd3NwULFjSDBg1yuJl6aGhoqvMMDQ1NV5ucjVZqHcnR2V/KEWUPHDhgnnnmGePv72+8vb1N7dq1zW+//WZXxzpCY2p/qd1o3Sojo5UeP37cNGvWzAQGBho/Pz/ToEEDs2vXLocb1qc2Yqd1/755Oa9du2b69OljgoODjaenp6lSpYrZuHGjwzydyeiyx8bGmh49epiQkBDj7u5uypUrZ2bPnm1X53b2J2dtcjZaaVrzTWnZsmWmSpUqxtPT0wQFBZk2bdo43PTeOspvan83jyCalJRkvvjiC/PYY4+Z7NmzG39/f1OxYkXz6aefOuz7zhw4cMBYLBaHEYVTG620dOnSDvNo27atw7ETHR1tXnvtNVOwYEHj5uZmgoODTaNGjcy+ffvs1tvNo4kaY8yvv/5qqlWrZnx8fEy+fPnMoEGDzKRJk+zasnHjRvPss8+a0NBQ4+HhYXLkyGEiIiLM999/bzcvZ/M3xpg///zTti5TG1H10KFDpkOHDiZfvnzGzc3N5MqVy1SrVs0MHTrUrl5sbKzx9vY2H3zwgdP5AEibxRhuAgMAAPCgsI5QvHjx4vvdlIfO5MmT9dprr+nYsWNcOQRuA+EQAADgAbJr1y5VrFhRGzZssPutH9KWmJioUqVKqW3bturfv//9bg7wUOJWFgAAAA+QMmXKaOrUqU5HU0bqjh07platWqlPnz73uynAQ4srhwAAAAAArhwCAAAAAAiHAAAAAAARDgEAAAAAklxvXQUPm+TkZJ08eVJ+fn6yWCz3uzkAAAAA7hNjjGJjY5U3b15ly5b2tUHCYRZ08uRJFShQ4H43AwAAAMAD4tixY8qfP3+adQiHWZCfn5+kGzuAv7//bc0jISFBy5YtU7169eTm5paZzcM9xHbMOtiWWQPbMetgW2YNbMesg22ZukuXLqlAgQK2jJAWwmEWZO1K6u/vf0fh0NvbW/7+/hxgDzG2Y9bBtswa2I5ZB9sya2A7Zh1sy1tLz8/NGJAGAAAAAEA4BAAAAAAQDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAeoDCYWRkpHr27OlQvmDBAlksFknStGnTZLFY1KBBA7s6MTExslgsWrNmja3MYrFowYIFtscJCQl64YUXlCdPHu3YsUOSVKhQIVksFm3atMlufj179lRkZKRd2YULF9SzZ08VKlRI7u7uypMnj9q3b6+jR4/a6kyYMEF+fn5KTEy0lV2+fFlubm6qUaOG3fzWrVsni8WiP//8M8NtAQAAAIDM5nq/G5BRrq6uWrlypVavXq2aNWum6zlXrlxRs2bN9Oeff2r9+vUqWrSobZqnp6fefPNNrV27NtXnX7hwQVWqVJG7u7vGjRunMmXK6PDhw3rnnXdUqVIlbdy4UUWKFFHNmjV1+fJlbd26VVWqVJF0IwSGhIRoy5YtunLliry9vSVJa9asUd68eRUWFpahtmR10XHXdOpSvKKvJMjP01UWi0Wu2SwK8fNUoI/H/W4egLskOu6azsRe1cWrCcru5aZgX475f7NTF6/o3OVruhh/Y3/I6euhPAHe97tZTv119pKUzUVJydLFq9fl5+kmfw9XXU1M0qWriXb7c3TcNZ29fFVJyUaJyUaxVxPl6+kqX3dX+bpm09WkZF26nqSLV67L19NVXm6u8nLNpoI5fBUdd00X4q4r9nqiLl9LUJC3h/L4c5wA99qt3q+s56+Y+OvK7uUuPw9XZfdyf2iO1YcuHPr4+Kh58+Z66623tHnz5lvWj4mJUePGjXXp0iWtX79eefLksZvepUsXjR8/Xj/99JMaNmzodB79+/fXyZMndeDAAYWEhEiSChYsqKVLl6p48eLq1q2bFi9erBIlSihv3rxas2aNLRyuWbNGTZo00erVq7VhwwbVqVPHVp4y3KanLVnZseg4dZy5Scv2nbaV1S4RotciS+ithdv0afNKKhDocx9bCOBucHbs1wsP0aSWVTjm/4X+/idWL8/+VSv2/29/qFMiRBOiKqtoTr/72DJ7J2KuSJIOno/Txz//peX77NvbI7KEoqb+orjriXq6bD592OxR9f72N3WsVkxj1+zXypuWr0OVInq7fhl1nfurw3vgO/XLKDHZ6OSleA3+aafd8zhOgHvrVu9XqZ2/Pn7+MV25nqh8D8Gx+sB0K82IwYMHa+fOnfrmm2/SrHf69GlFREQoOTlZa9eudQiG0o3unC+//LL69eun5ORkh+nJycmaM2eOWrZsaQuGVl5eXuratauWLl2qCxcuSLrRPXb16tW2OqtXr1ZkZKQiIiJs5devX9fGjRsdwuGt2pKVRcddczjYJGnl/tMau2a/yuYNVMeZmxQdd+0+tRDA3ZDasb9s32mO+X+hUxevOHywkqQV+0/r5dm/6tTFK/epZfai467p1a+3SJLGrfvTLhhKN9o7ds1+9awZLkkqmzdQL8/+VWXzBjoEQ0nqW7ukQzCUbrwHDl26S8eir+i/i3c6PI/jBLh3bvV+dSw6LtXzV495W3Xgn8sPxbH60F05lKS8efPqtddeU//+/fXMM8+kWu+1115TkSJFtHHjRlt3TmfeeecdTZ06VTNnzlTr1q3tpp07d04xMTEqWbKk0+eWLFlSxhgdOHBAlStXVmRkpHr16qXExETFx8dr27ZteuKJJ5SUlKSPP/5YkrRp0ybFx8c77RabVltSc+3aNV279r+d7dKlS5Ju/M4yISEhXfNIyfq8231+Rp2Mvqx1f52Wl4vjtA0HTuu1iOL6cMUunYy+LF/3h/I7jfviXm9H3D1ZdVumdeyv++t0ljvms+p2zCxnLsbplwPO94dfDpzWmYtxyuntdu8blsLJ6Mva+PcZdcrvq81/n0nzvcvLRfpPaKA+XLFLPf7/vSxl/asJCWm+B3o3LvOvOk7uJY7JrONub8tbvV+dj72S5vnL27XMfTtWM7JOHspwKElvvvmmPv/8c02ZMkXNmzd3Wuepp57Sd999p88//1y9evVKdV65cuVS3759NXDgQLVo0SJD7TDGSJJt0JyaNWsqLi5OW7ZsUXR0tMLCwhQcHKyIiAi1bt1acXFxWrNmjQoWLKgiRYpkSltGjBihIUOGOJQvW7YszVCcHsuXL7+j52fE7Fq+qU5LPrRNs2v56sBv63XgnrUo67iX2xF3V1bclmkd+1n1mM+K2zGzpLU/HNm2QUe23cPGpGFKhK/dv85Y37tS/pvS0W0b0lzukzs2/SuPk3uJYzLruJvb8lbnp1sdx5Luy7F65Ur6e108MOHQ399fFy9edCiPiYmRv7+/Q3n27NnVr18/DRkyRI0bN3Y6z1atWunpp59Whw4dlJSUpL59+6b6+r1799a4ceM0btw4u/JcuXIpe/bs2rNnj9Pn7du3TxaLxTbITbFixZQ/f36tXr1a0dHRioiIkCSFhISocOHC+uWXX7R69WrVqlUrw21JTb9+/dS7d2/b40uXLqlAgQKqV6+e03WXHgkJCVq+fLnq1q0rN7e7/y3tn2cuqdLoJalOn/tSDbWYvE5bXm+gsNy3t0z/Rvd6O+Luyarb8lbHflY75rPqdswsu0/FqNoHy1KdvqFPPZXOk/3eNSgVf565pCc+XKIpEb7qsPay4pOc17O+d6X8N6Vf+tRT9TSWe23POooYsyLV6VntOLmXOCazjru9LW/1frWhT700z19re9aRt5vrfTlWrb0K0+OBCYfh4eFavHixQ/mWLVtUokQJp8/p3r27Pv74Y40dOzbV+bZp00YuLi5q27atkpOT9cYbbzit5+vrqwEDBmjw4MF66qmnbOXZsmVT8+bNNXPmTL377rt2vzuMj4/XuHHjVL9+fQUFBdnKa9asqTVr1ig6Olqvv/66rTwiIkJLly7Vpk2b1L59+1TbnFpbUuPh4SEPD8cRkNzc3O744MiMeaRH3kBf1Sge4tCPW7rxg/zNR6JVo3iI8gb6cvK+DfdqO+Luy2rbMq1jv1541j3ms9p2zCy5A3xUvViIw292pBuDOuQO8Hkg1lveQF9VLZpbUpyqFM2tn/aecahjfe+KT5I2H4lW9WI3HlcrFuLw20FPN7c03wOvJOhfeZzcSxyTWcfd2pa3er/K4eed5vnrSqJULPj+HKsZec0HpoN6165d9ffff6tbt27avn27/vzzT3322WeaPHmyXcC6maenp4YMGWL7LV9qWrZsqa+++kpvv/22Ro4cmWq9zp07KyAgQLNnz7YrHzZsmEJCQlS3bl0tXrxYx44d088//6z69esrISFBn332mV39mjVrav369frjjz9sVw6lG+Hwiy++0NWrV295G47U2pJVBfp4aFLLKqoXbj/oj3W00p0nozWpZZWHZhhgAOmT2rFvHf2NY/7fJU+AtyZEVVadEvb7Q50SIfo8qvIDczuLQB8Pfdq8kiTplRphDvtvnf9/7xqzep8kaefJaE2IqqydJ6P1WmQJ1U6xfO+v3KtxLSo7fQ98p34ZFQz01oAnyzo8j+MEuHdu9X5VINAn1fPXx88/pmI5fR+KY/WBuXJYqFAhrVu3Tv3791e9evV09epVhYWFadq0aXr++edTfV7btm31wQcfpNrt0yoqKkouLi5q2bKlkpOT9fbbbzvUcXNz03//+1+9+OKLduU5c+bUpk2b9O6776pLly46deqUcuTIoQYNGmjGjBkqWLCgXf2aNWsqPj5e4eHhyp07t608IiJCsbGxKlq0qAoUKJBme1NrS1ZWINBHc9o/brvPoa+nq1wsFrlkk6a1qvpQHFAAMs567FvvGxXg6abc3Nv0X6toTj9Nb1PVdp/DAC835XoA73OYL7u3tksqksNHHzV71HafQ18PNwV4uOpqUpJW9qhttz9Pa1VVZy9f1cfPPWq7z6GPh6v8/v8+hxNfqHzjPofx1+Xj7ipv9//d5zC7t7s+b1FZsdcTFXctQYHe7srj78VxAtxDt3q/uvn8FfP/5y9/d1dl93547nNoMdYRVZBlXLp0SQEBAbp48eId/ebQer9Fulk8vNiOWQfbMmtgO2YdbMusge2YdbAtU5eRbPDAdCsFAAAAANw/hEMAAAAAAOEQAAAAAEA4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAD0E4bNeunZ555hmH8jVr1shisSgmJsbuscViUbZs2RQQEKCKFSvqjTfe0KlTp+64HevXr1f16tWVI0cOeXl5KTw8XB999JFdnS+++EI1atRQYGCgAgMDVadOHf366692dcaPH69y5crJ399f/v7+qlq1qhYvXpzq63bp0kUWi0Vjxoy542X4NzkZHaej/8Tq0D+x2n4iWn+dO6fD/8Rqx4lo/XzgjHaciNaR85fvdzMBAACAB4br/W5AZtu/f7/8/f116dIl/f777xo1apQmT56sNWvWqGzZsrc9Xx8fH7366qsqV66cfHx8tH79enXp0kU+Pj7q3LmzpBsBNSoqStWqVZOnp6dGjRqlevXqaffu3cqXL58kKX/+/Bo5cqSKFSsmSfryyy/VpEkTbdu2TaVLl7Z7zQULFmjz5s3Kmzfvbbf73+jQuVgZGSUZqevcLaoaGqg2VYur0+xftWL/aVu9OiVCNP6FyiqWy+8+thYAAAB4MDzwVw4zKjg4WCEhIQoLC9MLL7ygX375Rbly5dIrr7xyR/OtWLGioqKiVLp0aRUqVEitWrVS/fr1tW7dOludmTNnqmvXrqpQoYLCw8P1xRdfKDk5WStXrrTVeeqpp9SwYUOFhYUpLCxMw4YNk6+vrzZt2mT3eidOnNCrr76qmTNnys3N7Y7a/m9yLDpOsdcSdflakrrO3aIV+0+rQ7XiemWOfTCUpBX7T+uVOb9yBREAAABQFrxymJKXl5defvll9erVS2fPnlVwcHCmzHfbtm3asGGDhg4dmmqdK1euKCEhQUFBQU6nJyUlad68eYqLi1PVqlVt5cnJyWrdurVef/11h6uJzly7dk3Xrl2zPb506ZIkKSEhQQkJCeldJDvW593u8++X87FXZMyN//9y4LS8XKToK1dt/0/plwOnFR0Xr7z+Hve2offIw7od4YhtmTWwHbMOtmXWwHbMOtiWqcvIOnkowuGiRYvk6+trV5aUlJTu54eHh0uSDh8+fMfhMH/+/Dp37pwSExM1ePBgdezYMdW6b731lvLly6c6derYle/cuVNVq1bV1atX5evrq++++06lSpWyTX/vvffk6uqqHj16pKtNI0aM0JAhQxzKly1bJm9v73QumXPLly+/o+ffT7Nr3dhnjm7bYPu/M0e2bdCRbfeqVffHw7wdYY9tmTWwHbMOtmXWwHbMOtiWjq5cuZLuug9FOKxZs6bGjx9vV7Z582a1atUqXc83/38pyWKx3HFb1q1bp8uXL2vTpk166623VKxYMUVFRTnUGzVqlGbPnq01a9bI09PTblqJEiX0xx9/KCYmRt9++63atm2rtWvXqlSpUvrtt980duxY/f777+lub79+/dS7d2/b40uXLqlAgQKqV6+e/P39b2s5ExIStHz5ctWtW/eh6ta6+1SM7cph9Q+XSZJ+6VNP1T9YlupzNvSpp9J5st+D1t17D+t2hCO2ZdbAdsw62JZZA9sx62Bbps7aqzA9Hopw6OPjYxvAxer48ePpfv7evXslSYUKFbrjthQuXFiSVLZsWZ05c0aDBw92CIfvv/++hg8frhUrVqhcuXIO83B3d7ctz2OPPaYtW7Zo7Nix+vzzz7Vu3TqdPXtWBQsWtNVPSkpSnz59NGbMGB0+fNhhfh4eHvLwcOwW6ebmdscHR2bM417K4eet6LjrkqTqxUK0Yv9pBXp72v6fUp0SIQr08XqolvF2PGzbEaljW2YNbMesg22ZNbAdsw62paOMrI8sNyBNSvHx8Zo4caKeeOIJ5cqVK1PnbYyx+62fJI0ePVr//e9/tWTJEj322GMZnk/r1q21Y8cO/fHHH7a/vHnz6vXXX9fSpUsztf1ZUYFAH/l5uMrXw0XjWlRSnRIhmrLhL41/obLqlAixq1unRIgmvFBZoTlS73IKAAAA/Fs8FFcOM+Ls2bO6evWqYmNj9dtvv2nUqFH6559/NH/+/Dua72effaaCBQvafr+4fv16vf/+++revbutzqhRozRgwADNmjVLhQoV0unTN65U+fr62n4z+fbbb+vJJ59UgQIFFBsbqzlz5mjNmjVasmSJJClHjhzKkSOH3Wu7ubkpJCREJUqUuKNl+LconMtPJ6PjlJiUrIlRlXXpWqKMruqL//9/THyCsnu5KcDTjWAIAAAA/L8sFw5LlCghi8UiX19fFSlSRPXq1VPv3r0VEhJy6yenITk5Wf369dOhQ4fk6uqqokWLauTIkerSpYutzrhx43T9+nU999xzds8dNGiQBg8eLEk6c+aMWrdurVOnTikgIEDlypXTkiVLVLdu3TtqH+zlDfS5300AAAAAHioPfDicNm2a0/LIyEjbQDPOHme27t27210ldMbZ7wFTmjx5coZfOz3zBQAAAIA7keV/cwgAAAAAuDXCIQAAAACAcAgAAAAAIBwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAADdRjg8evSojDEO5cYYHT16NFMaBQAAAAC4tzIcDgsXLqxz5845lF+4cEGFCxfOlEYBAAAAAO6tDIdDY4wsFotD+eXLl+Xp6ZkpjQIAAAAA3Fuu6a3Yu3dvSZLFYtGAAQPk7e1tm5aUlKTNmzerQoUKmd5AAAAAAMDdl+5wuG3bNkk3rhzu3LlT7u7utmnu7u4qX768+vbtm/ktBAAAAADcdekOh6tXr5YktW/fXmPHjpW/v/9daxQAAAAA4N7K8G8Op06dKn9/fx04cEBLly5VfHy8JDkdwRQAAAAA8HDIcDi8cOGCateurbCwMDVs2FCnTp2SJHXs2FF9+vTJ9AYCAAAAAO6+DIfDnj17ys3NTUePHrUblKZFixZasmRJpjYOAAAAAHBvpPs3h1bLli3T0qVLlT9/frvy4sWL68iRI5nWMAAAAADAvZPhK4dxcXF2Vwyt/vnnH3l4eGRKowAAAAAA91aGw+ETTzyh6dOn2x5bLBYlJydr9OjRqlmzZqY2DgAAAABwb2S4W+no0aMVGRmprVu36vr163rjjTe0e/duXbhwQb/88svdaCMAAAAA4C7L8JXDUqVKaceOHapcubLq1q2ruLg4NW3aVNu2bVPRokXvRhsBAAAAAHdZhq8cSlJISIiGDBmS2W0BAAAAANwnGQ6HO3bscFpusVjk6empggULMjANAAAAADxkMhwOK1SoIIvFIkkyxkiS7bEkubm5qUWLFvr888/l6emZSc0EAAAAANxNGf7N4XfffafixYtr4sSJ2r59u/744w9NnDhRJUqU0KxZszR58mStWrVK77zzzt1oLwAAAADgLsjwlcNhw4Zp7Nixql+/vq2sXLlyyp8/vwYMGKBff/1VPj4+6tOnj95///1MbSwAAAAA4O7I8JXDnTt3KjQ01KE8NDRUO3fulHSj6+mpU6fuvHUAAAAAgHsiw+EwPDxcI0eO1PXr121lCQkJGjlypMLDwyVJJ06cUO7cuTOvlQAAAACAuyrD3Uo/++wzPf3008qfP7/KlSsni8WiHTt2KCkpSYsWLZIkHTx4UF27ds30xgIAAAAA7o4Mh8Nq1arp8OHDmjFjhv78808ZY/Tcc8/pxRdflJ+fnySpdevWmd5QAAAAAMDdk6FwmJCQoBIlSmjRokV6+eWX71abAAAAAAD3WIZ+c+jm5qZr167Z3dcQAAAAAPDwy/CANN27d9d7772nxMTEu9EeAAAAAMB9kOHfHG7evFkrV67UsmXLVLZsWfn4+NhNnz9/fqY1DgAAAABwb2Q4HGbPnl3NmjW7G20BAAAAANwnGQ6HU6dOvRvtAAAAAADcRxn+zSEAAAAAIOvJ8JVDSfrmm2/09ddf6+jRo7p+/brdtN9//z1TGgYAAAAAuHcyfOXw448/Vvv27RUcHKxt27apcuXKypEjhw4ePKgnn3zybrQRAAAAAHCXZTgcjhs3ThMnTtSnn34qd3d3vfHGG1q+fLl69Oihixcv3o02AgAAAADusgyHw6NHj6patWqSJC8vL8XGxkqSWrdurdmzZ2du6wAAAAAA90SGw2FISIjOnz8vSQoNDdWmTZskSYcOHZIxJnNbBwAAAAC4JzIcDmvVqqUffvhBkvTSSy+pV69eqlu3rlq0aKFnn3020xsIAAAAALj7Mjxaaf/+/ZUvXz5J0ssvv6ygoCCtX79eTz31FAPSAAAAAMBDKsPhsFixYjp16pSCg4MlSc2bN1fz5s11/vx5BQcHKykpKdMbCQAAAAC4uzLcrTS13xVevnxZnp6ed9wgAAAAAMC9l+4rh71795YkWSwWDRw4UN7e3rZpSUlJ2rx5sypUqJDpDQQAAAAA3H3pDofbtm2TdOPK4c6dO+Xu7m6b5u7urvLly6tv376Z30IAAAAAwF2X7nC4evVqSVL79u01duxY+fv737VGAQAAAADurQwPSDN16tS70Q4AAAAAwH2U4QFpAAAAAABZD+EQAAAAAEA4BAAAAAAQDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABAhEMAAAAAgAiHAAAAAAARDgEAAAAAIhwCAAAAAEQ4BAAAAACIcAgAAAAAEOEQAAAAACDCIQAAAABA9zkctmvXTs8884xD+Zo1a2SxWBQTE2P32GKxKFu2bAoICFDFihX1xhtv6NSpU2m+xvbt2xUVFaUCBQrIy8tLJUuW1NixY+3qXL16Ve3atVPZsmXl6urqtE3z589X3bp1lStXLvn7+6tq1apaunSpQ72YmBh169ZNefLkkaenp0qWLKmffvrJNn3EiBGqVKmS/Pz8FBwcrGeeeUb79++3m4d1WVP+jR49Os1lBYBbOXXxinaciNbPB85ox4loHfonVtFx1+53swAAwAPA9X43ICP2798vf39/Xbp0Sb///rtGjRqlyZMna82aNSpbtqzT5/z222/KlSuXZsyYoQIFCmjDhg3q3LmzXFxc9Oqrr0qSkpKS5OXlpR49eujbb791Op+ff/5ZdevW1fDhw5U9e3ZNnTpVTz31lDZv3qyKFStKkq5fv666desqODhY33zzjfLnz69jx47Jz8/PNp+1a9eqW7duqlSpkhITE9W/f3/Vq1dPe/bskY+PjyQ5BN7FixfrpZdeUrNmze54HQL49/r7n1i9PPtXrdh/2lZWp0SIPn7+MV25nqh8gT73sXUAAOB+e6jCYXBwsLJnz66QkBCFhYWpSZMmqlixol555RWtX7/e6XM6dOhg97hIkSLauHGj5s+fbwuHPj4+Gj9+vCTpl19+sV2xvNmYMWPsHg8fPlwLFy7UDz/8YAuHU6ZM0YULF7Rhwwa5ublJkkJDQ+2et2TJErvHU6dOVXBwsH777Tc98cQTkqSQkBC7OgsXLlTNmjVVpEiR1FYNAKTp1MUrDsFQklbsP60e87bqnQZl5O3uqkAfj/vUQgAAcL89VOEwJS8vL7388svq1auXzp49q+Dg4HQ97+LFiwoKCrqj105OTlZsbKzdfL7//ntVrVpV3bp108KFC5UrVy69+OKLevPNN+Xi4pJqWySl2p4zZ87oxx9/1JdffplqW65du6Zr1/7XLezSpUuSpISEBCUkJGR42azPvflfPJzYjlnHnW7LMxfj9MuB0/Jycir65cBpebuW0cnoy/J156fodxPHZNbBtswa2I5ZB9sydRlZJ/c9HC5atEi+vr52ZUlJSel+fnh4uCTp8OHD6QqHGzdu1Ndff60ff/wxYw1N4YMPPlBcXJyaN29uKzt48KBWrVqlli1b6qefftJff/2lbt26KTExUQMHDnSYhzFGvXv31uOPP64yZco4fZ0vv/xSfn5+atq0aaptGTFihIYMGeJQvmzZMnl7e9/G0v3P8uXL7+j5eDCwHbOOO9mWs2v5pjrt5I5NkqQDtz13ZATHZNbBtswa2I5ZB9vS0ZUrV9Jd976Hw5o1a9q6dFpt3rxZrVq1StfzjTGSbgziciu7d+9WkyZNNHDgQNWtWzfjjf1/s2fP1uDBg7Vw4UK7QJqcnKzg4GBNnDhRLi4uevTRR3Xy5EmNHj3aaTh89dVXtWPHjlS7xEo3uqq2bNlSnp6eqdbp16+fevfubXt86dIlFShQQPXq1ZO/v/9tLWNCQoKWL1+uunXr2rrI4uHDdsw67nRb7j4Vo2ofLEt1+tqedeTt5qqw3Ld3zkD6cExmHWzLrIHtmHWwLVNn7VWYHvc9HPr4+KhYsWJ2ZcePH0/38/fu3StJKlSoUJr19uzZo1q1aqlTp0565513MtxOq7lz5+qll17SvHnzVKdOHbtpefLkkZubm10X0pIlS+r06dO6fv263N3dbeXdu3fX999/r59//ln58+d3+lrr1q3T/v37NXfu3DTb5OHhIQ8Px98Jubm53fHBkRnzwP3Hdsw6bndb5g7wUfViIQ6/OZRuDEpzJVEqFuzLfnKPcExmHWzLrIHtmHWwLR1lZH081D8uiY+P18SJE/XEE08oV65cqdbbvXu3atasqbZt22rYsGG3/XqzZ89Wu3btNGvWLDVq1MhhevXq1XXgwAElJyfbyv7880/lyZPHFgyNMXr11Vc1f/58rVq1SoULF0719SZPnqxHH31U5cuXv+02A4Ak5Qnw1oSoyqpTwn7AK+topcVy+jIYDQAA/3L3/cphRpw9e1ZXr15VbGysfvvtN40aNUr//POP5s+fn+pzrMGwXr166t27t06fvvGtuYuLi12g3LNnj65fv64LFy4oNjZWf/zxhySpQoUKkm4EwzZt2mjs2LGqUqWKbT5eXl4KCAiQJL3yyiv65JNP9Nprr6l79+7666+/NHz4cPXo0cP2Ot26ddOsWbO0cOFC+fn52eYTEBAgLy8vW71Lly5p3rx5+uCDD+58xQGApKI5/TS9TVWdu3xNMfEJCvByk7+7q7J7uxMMAQDAwxUOS5QoIYvFIl9fXxUpUsQW+FLe+uFm8+bN07lz5zRz5kzNnDnTVh4aGqrDhw/bHjds2FBHjhyxPbbensL6m8bPP/9ciYmJ6tatm7p162ar17ZtW02bNk2SVKBAAS1btky9evVSuXLllC9fPr322mt68803bfWtv6+MjIy0a+fUqVPVrl072+M5c+bIGKOoqKj0rRwASIc8Ad7KE3BnA1UBAICs6b6GQ2uoSikyMtIWypw9zojBgwdr8ODBt6x3c1B0Zs2aNel6vapVq2rTpk2pTk/vcnTu3FmdO3dOV10AAAAAuFMP9W8OAQAAAACZg3AIAAAAACAcAgAAAAAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAABEOAQAAAAAiHAIAAAAABDhEAAAAAAgwiEAAAAAQIRDAAAAAIAIhwAAAAAAEQ4BAAAAACIcAgAAAAD0gIfDdu3ayWKxaOTIkXblCxYskMVisSszxuiLL75Q1apV5e/vL19fX5UuXVqvvfaaDhw4YFf30qVL6t+/v8LDw+Xp6amQkBDVqVNH8+fPlzEmzbak/CtdurStzhdffKEaNWooMDBQgYGBqlOnjn799Ve7+cTGxqpnz54KDQ2Vl5eXqlWrpi1bttjVGTx4sMLDw+Xj42Obz+bNmzO8/gAAAAAgvR7ocChJnp6eeu+99xQdHZ1qHWOMXnzxRfXo0UMNGzbUsmXLtGPHDn388cfy8vLS0KFDbXVjYmJUrVo1TZ8+Xf369dPvv/+un3/+WS1atNAbb7yhixcvOn2NsWPH6tSpU7a/Y8eOKSgoSM8//7ytzpo1axQVFaXVq1dr48aNKliwoOrVq6cTJ07Y6nTs2FHLly/XV199pZ07d6pevXqqU6eOXZ2wsDB9+umn2rlzp9avX69ChQqpXr16Onfu3J2synsuOu6a9pyK0fq/z2r78Wj9dfaS/jx7SZsOndPf52K140S01v99VjtORGvnyRjtOHGjTnTctfvddAAAAOBfx/V+N+BW6tSpowMHDmjEiBEaNWqU0zpz587VnDlztHDhQj399NO28iJFiqh27dp2VwPffvttHT58WH/++afy5s1rKw8LC1NUVJQ8PT2dvkZAQIACAgJsjxcsWKDo6Gi1b9/eVjZz5ky753zxxRf65ptvtHLlSrVp00bx8fH69ttvtXDhQj3xxBOSblwlXLBggcaPH28LsS+++KLdfD788ENNnjxZO3bsUO3atdNcXw+KY9Fx6jhzk5btO20rq10iREOeLKdgfw+9POdXrdhvP+21yBL6/JcD6lu7pIrl9FX+QJ/70XQAAADgX+mBv3Lo4uKi4cOH65NPPtHx48ed1pk9e7ZKlChhFwxvZu2CmpycrDlz5qhly5Z2wdDK19dXrq7py8uTJ09WnTp1FBoammqdK1euKCEhQUFBQZKkxMREJSUlOQRQLy8vrV+/3uk8rl+/rokTJyogIEDly5dPV9vut+i4aw7BUJJW7j+txORkdZ27xS4YWqeNXbNfFfIFauiSXVq85yRXEAEAAIB76IG/cihJzz77rCpUqKBBgwZp8uTJDtP//PNPlShRwq6sZ8+emjRpkiQpe/bsOv5/7d17cNTlvcfxzwaSJYRkCYbcICJHwkWCQIDDzXIXcgotrVhBIRqxDLSD4GBnLAwWUCAZsHjaWnXKIahVInVAaSsXgxYECZExWAiXEmoCBRIUmwsSSIL5nj8yLG5zEUOA3c37NcMMeZ7f79ln98MX+O7lt6dO6dy5cyouLlb37t2vaz+FhYXasmWL1q1b1+Bxv/zlL9WhQweNGTNGkhQaGqrBgwfr2WefVY8ePRQVFaWMjAxlZ2crPj7e49y//vWvmjJlisrLyxUTE6PMzExFRETUeTsVFRWqqLjaSJWVlUmSqqqqVFVV1aj7eOW8xpx/pvgr7corUnCL2nOtA6WPjtc9t+d4keYOj9eq7bmaOzxeZ4q/Upsgr3/+wqtdT47wLmTpH8jRf5ClfyBH/0GW9fsuj4nD6rsCixdISUlRSUmJ3nnnHX344YcaNWqUDhw4oGPHjunHP/6x++2iPXr0ULdu3fTOO++4z/3iiy9UWlqqjRs3avny5SopKdHZs2cVHR2t559/Xk888USj95Wamqpf//rXOnPmjIKCguo8ZsWKFUpLS9OOHTt09913u8f/+c9/avr06frwww/VokULJSYmqmvXrsrJydHhw4fdx124cEGFhYU6d+6cVq9erQ8++EDZ2dmKjIysdVuLFy/WkiVLao2vW7dOrVu3bvT9BAAAAODbysvL9dBDD6m0tFRhYWENHusTrxxK0rBhwzRu3DgtWLBAKSkpHnPx8fE6evSox1j79u3Vvn17j2aqffv2Cg8P15EjRxq9DzNTenq6kpOT620Mn3vuOS1fvlzbt2/3aAwl6c4779TOnTt14cIFlZWVKSYmRpMnT1bnzp09jgsJCVGXLl3UpUsXDRo0SPHx8VqzZo3mz59f6/bmz5+vefPmuX8uKytTXFycxo4d+61/AOpTVVWlzMxM3XvvvQoMDPxO5x47W6YBK7fWObfziTEa/r/b6z13/WPf0+Q1u7T+se/pv9qFqGtU4/aPGteTI7wLWfoHcvQfZOkfyNF/kGX9rryr8Fr4THMoSWlpaerTp4+6du3qMf7ggw/qoYce0qZNmzRx4sR6zw8ICNDkyZP1xz/+UYsWLar1ucMLFy7I6XQ2+LnDnTt36vjx43rsscfqnF+5cqWWLl2qbdu2qX///vWuExISopCQEBUXF2vbtm31XmznCjPzeOvoNzmdTjmdzlrjgYGB110cjVkjNryNvhcfXeszh5JUXiUN7RJd6zOHUs1FabJPFGtIl2gVna/QPXdGUdxNpCn+LMA7kKV/IEf/QZb+gRz9B1nW9l0eD5/6QFevXr00depU/e53v/MYnzJliu6//35NmTJFzzzzjLKzs1VQUKCdO3dq/fr1atHi6gfcli9frri4OA0cOFCvvfaaDh8+rLy8PKWnp6tPnz766quvGtzDmjVrNHDgQCUkJNSaW7FihRYuXKj09HTdcccdKioqUlFRkcea27Zt09atW5Wfn6/MzEyNHDlS3bp1c1/19MKFC1qwYIH27t2rEydOKCcnRz/96U916tQpj6/N8GbhIU7939RBGts92mN8dLdotQwI0IuTB2hMt9pzc0d006eni7UwKUH/c1eswkNqN7wAAAAAbgyfeuVQkp599ln96U9/8hhzOBxav369Vq9erbVr12rFihWqqqpSx44dNXr0aK1atcp9bHh4uPbu3au0tDQtXbpUJ06cUHh4uHr16qWVK1d6fF3FfyotLdWGDRv0m9/8ps75F198UZWVlbr//vs9xhctWqTFixe715g/f75OnTqldu3aadKkSVq2bJm7o2/RooWOHj2qV199VefOndNtt92mAQMGaNeuXerZs2djHrJbIi48RG8+eo8Kyy6quLxSIc5AhQS1kEn68kKFXp7y37pQeVlll6oU1ipQAQ6Hqq1aq+5LVPsQJ40hAAAAcJN5dXP4yiuv1Brr1KmTLl26VGs8ICBAM2fO1MyZM791XZfLpdTUVKWmpn6n/bhcLpWXl9c7X1BQ8K1rPPDAA3rggQfqnW/VqpU2btz4nfblrcJp8gAAAACf4VNvKwUAAAAA3Bg0hwAAAAAAmkMAAAAAAM0hAAAAAEA0hwAAAAAA0RwCAAAAAERzCAAAAAAQzSEAAAAAQDSHAAAAAADRHAIAAAAARHMIAAAAABDNIQAAAABANIcAAAAAANEcAgAAAABEcwgAAAAAEM0hAAAAAEA0hwAAAAAA0RwCAAAAAERzCAAAAAAQzSEAAAAAQDSHAAAAAADRHAIAAAAARHMIAAAAABDNIQAAAABANIcAAAAAANEcAgAAAABEcwgAAAAAEM0hAAAAAEBSy1u9ATQ9M5MklZWVNXqNqqoqlZeXq6ysTIGBgU21Ndxk5Og/yNI/kKP/IEv/QI7+gyzrd6UnuNIjNITm0A+dP39ekhQXF3eLdwIAAADAG5w/f14ul6vBYxx2LS0kfEp1dbXOnDmj0NBQORyORq1RVlamuLg4/etf/1JYWFgT7xA3Czn6D7L0D+ToP8jSP5Cj/yDL+pmZzp8/r9jYWAUENPypQl459EMBAQHq2LFjk6wVFhZGgfkBcvQfZOkfyNF/kKV/IEf/QZZ1+7ZXDK/ggjQAAAAAAJpDAAAAAADNIerhdDq1aNEiOZ3OW70VXAdy9B9k6R/I0X+QpX8gR/9Blk2DC9IAAAAAAHjlEAAAAABAcwgAAAAAEM0hAAAAAEA0hz7n9OnTmjZtmm677Ta1bt1affr00SeffOKeNzMtXrxYsbGxCg4O1ogRI3To0KFa62RlZWnUqFEKCQlR27ZtNWLECF28eNE9X1xcrOTkZLlcLrlcLiUnJ6ukpMRjjX379mn06NFq27atwsPDNXbsWH366acN7r+iokKPP/64IiIiFBISoh/+8Ic6derUdT0mvsjXcxwxYoQcDofHrylTplzXY+KrvCnL999/X0OGDFFoaKhiYmL01FNP6fLlyw3un5qs4es5UpNX3awsly1bpiFDhqh169Zq27ZtnXs5efKkfvCDHygkJEQRERGaM2eOKisrG9w/NVnD13OkJq/ypiznzp2rfv36yel0qk+fPte0/2ZXkwaf8e9//9s6depkKSkplp2dbfn5+bZ9+3Y7fvy4+5i0tDQLDQ21DRs22MGDB23y5MkWExNjZWVl7mP27NljYWFhlpqaarm5uXbs2DF766237NKlS+5jkpKSLCEhwfbs2WN79uyxhIQEmzBhgnu+rKzMwsPDLSUlxY4ePWq5ubk2adIki4yMtMrKynrvw6xZs6xDhw6WmZlpOTk5NnLkSOvdu7ddvny5iR8t7+UPOQ4fPtxmzJhhhYWF7l8lJSVN/Eh5P2/K8u9//7sFBQXZkiVLLC8vz3bs2GHdu3e3J598ssH7QE36R47UZI2bmeWvfvUrW7Vqlc2bN89cLletvVy+fNkSEhJs5MiRlpOTY5mZmRYbG2uzZ89u8D5Qk/6RIzVZw5uyNDN7/PHH7YUXXrDk5GTr3bv3Nd2H5laTNIc+5KmnnrJ77rmn3vnq6mqLjo62tLQ099ilS5fM5XLZyy+/7B4bOHCgLVy4sN51Dh8+bJJs79697rGsrCyTZEePHjUzs3379pkkO3nypPuYAwcOmCSPgv+mkpISCwwMtDfffNM9dvr0aQsICLCtW7c2cM/9i6/naFbzj97cuXMbvJ/NgTdlOX/+fOvfv7/HeW+//ba1atXK4x/Yb6Ima/h6jmbU5BU3K8tvWrt2bZ3/Ed28ebMFBATY6dOn3WMZGRnmdDqttLS0zrWoyRq+nqMZNXmFN2X5TYsWLbqm5rA51iRvK/Uhf/7zn9W/f3/95Cc/UWRkpPr27avVq1e75/Pz81VUVKSxY8e6x5xOp4YPH649e/ZIkj7//HNlZ2crMjJSQ4YMUVRUlIYPH67du3e7z8nKypLL5dLAgQPdY4MGDZLL5XKv061bN0VERGjNmjWqrKzUxYsXtWbNGvXs2VOdOnWqc/+ffPKJqqqqPPYXGxurhIQE97rNga/neMUbb7yhiIgI9ezZU7/4xS90/vz5Jnl8fIk3ZVlRUaFWrVp57C84OFiXLl3yePvON1GTNXw9xyuoyZuX5bXIyspSQkKCYmNj3WPjxo1TRUUFNfktfD3HK6hJ78qyMZpjTdIc+pDPPvtML730kuLj47Vt2zbNmjVLc+bM0WuvvSZJKioqkiRFRUV5nBcVFeWe++yzzyRJixcv1owZM7R161YlJiZq9OjRysvLc68TGRlZ6/YjIyPd64SGhmrHjh16/fXXFRwcrDZt2mjbtm3avHmzWrZsWef+i4qKFBQUpPDw8Hr31xz4eo6SNHXqVGVkZGjHjh16+umntWHDBt13333X+cj4Hm/Kcty4cdqzZ48yMjL09ddf6/Tp01q6dKkkqbCwsM79U5M1fD1HiZq84mZleS2Kiopq3U54eLiCgoLqrS9qsoav5yhRk1d4U5aN0Rxrsv7//cHrVFdXq3///lq+fLkkqW/fvjp06JBeeuklPfzww+7jHA6Hx3lm5h6rrq6WJM2cOVOPPvqoe533339f6enpSk1NrXON/1zn4sWLmj59uoYOHer+T8xzzz2n73//+9q3b5+Cg4Ov+X59c93mwB9ynDFjhvv3CQkJio+PV//+/ZWTk6PExMRGPS6+yJuyHDt2rFauXKlZs2YpOTlZTqdTTz/9tHbv3q0WLVp8p/tFTfpejtRkjZuZ5bX4tryvFTXpezlSkzW8Lcum4s81ySuHPiQmJkZ33XWXx1iPHj108uRJSVJ0dLQk1Xom4/PPP3c/IxMTEyNJ37rO2bNna93+F1984V5n3bp1Kigo0Nq1azVgwAANGjRI69atU35+vjZt2lTn/qOjo1VZWani4uJ699cc+HqOdUlMTFRgYOANfwbP23hTlpI0b948lZSU6OTJkzp37pwmTpwoSercuXOd+6cma/h6jnWhJq+6EVlei+jo6Fq3U1xcrKqqqnrri5qs4es51oWavOpWZdkYzbEmaQ59yNChQ/WPf/zDY+zYsWPuz4Z17txZ0dHRyszMdM9XVlZq586dGjJkiCTpjjvuUGxsbIPrDB48WKWlpfr444/d89nZ2SotLXWvU15eroCAAI9nTa78fOUZnv/Ur18/BQYGeuyvsLBQubm57nWbA1/PsS6HDh1SVVWV+y/w5sKbsrzC4XC4LweekZGhuLi4ep+lpiZr+HqOdaEmr7oRWV6LwYMHKzc31+PtwO+9956cTqf69etX5znUZA1fz7Eu1ORVtyrLxmiWNXnTL4GDRvv444+tZcuWtmzZMsvLy7M33njDWrduba+//rr7mLS0NHO5XLZx40Y7ePCgPfjgg7UuB/z8889bWFiYvfXWW5aXl2cLFy60Vq1aeVydMikpye6++27LysqyrKws69Wrl8fl1o8cOWJOp9N+9rOf2eHDhy03N9emTZtmLpfLzpw5Y2Zmp06dsm7dull2drb7vFmzZlnHjh1t+/btlpOTY6NGjfLrywHXxddzPH78uC1ZssT27dtn+fn59u6771r37t2tb9++zSpHM+/K0sxsxYoVduDAAcvNzbVnnnnGAgMD7e2333bPU5N18/UcqcmrbmaWJ06csP3799uSJUusTZs2tn//ftu/f7+dP3/ezK5+BcLo0aMtJyfHtm/fbh07dvT4CgRqsm6+niM1eZU3ZWlmlpeXZ/v377eZM2da165d3cdUVFSYGTVpxldZ+Jy//OUvlpCQYE6n07p3725/+MMfPOarq6tt0aJFFh0dbU6n04YNG2YHDx6stU5qaqp17NjRWrdubYMHD7Zdu3Z5zH/55Zc2depUCw0NtdDQUJs6daoVFxd7HPPee+/Z0KFDzeVyWXh4uI0aNcqysrLc8/n5+SbJ/va3v7nHLl68aLNnz7Z27dpZcHCwTZgwweNrFJoLX87x5MmTNmzYMGvXrp0FBQXZnXfeaXPmzLEvv/yyaR4cH+NNWY4cOdJcLpe1atXKBg4caJs3b/aYpybr58s5UpOeblaWjzzyiEmq9eub9XXixAkbP368BQcHW7t27Wz27Nke38tGTdbPl3OkJj15U5bDhw+v85j8/HwzoybNzBxmZjfpRUoAAAAAgJfiM4cAAAAAAJpDAAAAAADNIQAAAABANIcAAAAAANEcAgAAAABEcwgAAAAAEM0hAAAAAEA0hwAAAAAA0RwCAAAAAERzCACAT0lJSZHD4dCsWbNqzf385z+Xw+FQSkqK+9gf/ehHtc51OBwKDAxUVFSU7r33XqWnp6u6uvom3QMAgLeiOQQAwMfExcXpzTff1MWLF91jly5dUkZGhm6//fYGz01KSlJhYaEKCgq0ZcsWjRw5UnPnztWECRN0+fLlG711AIAXozkEAMDHJCYm6vbbb9fGjRvdYxs3blRcXJz69u3b4LlOp1PR0dHq0KGDEhMTtWDBAm3atElbtmzRK6+8coN3DgDwZjSHAAD4oEcffVRr1651/5yenq7p06c3aq1Ro0apd+/eHs0mAKD5oTkEAMAHJScna/fu3SooKNCJEyf00Ucfadq0aY1er3v37iooKGi6DQIAfE7LW70BAADw3UVERGj8+PF69dVXZWYaP368IiIiGr2emcnhcDThDgEAvobmEAAAHzV9+nTNnj1bkvT73//+utY6cuSIOnfu3BTbAgD4KN5WCgCAj0pKSlJlZaUqKys1bty4Rq/zwQcf6ODBg5o0aVIT7g4A4Gt45RAAAB/VokULHTlyxP37a1FRUaGioiJ9/fXXOnv2rLZu3arU1FRNmDBBDz/88I3cLgDAy9EcAgDgw8LCwuqdq66uVsuWnv/Ub926VTExMWrZsqXCw8PVu3dv/fa3v9UjjzyigADeUAQAzZnDzOxWbwIAADS9pKQkdenSRS+88MKt3goAwAfwFCEAAH6muLhY7777rnbs2KExY8bc6u0AAHwEbysFAMDPTJ8+Xfv27dOTTz6piRMn3urtAAB8BG8rBQAAAADwtlIAAAAAAM0hAAAAAEA0hwAAAAAA0RwCAAAAAERzCAAAAAAQzSEAAAAAQDSHAAAAAADRHAIAAAAARHMIAAAAAJD0/xhysRZNtjkOAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1000x1000 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "\n",
     "### 3.3.3 Target vs. MJD\n",
@@ -1078,7 +1724,7 @@
     "# Add labels and title\n",
     "plt.xlabel('MJD')\n",
     "plt.ylabel(col_target)\n",
-    "title = \"\"\"MJDs of %s Observations of Different Science Program Targets on %s\"\"\" %(instrument, day_obs)\n",
+    "title = \"\"\"MJDs of %s Observations of Different Science Program Targets\\n between %s and %s (inclusive)\"\"\" %(instrument, day_obs_start, day_obs_end)\n",
     "plt.title(title)\n",
     "plt.grid(True)\n"
    ]
@@ -1093,10 +1739,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "3d2d7e9a-a8c5-43e3-9fb3-f8b7cf5b6e87",
-   "metadata": {},
+   "execution_count": 42,
+   "id": "c1c4ccc9-25a5-4ddc-853c-01da52b614fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.616682Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.616552Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.618728Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.618386Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.616669Z"
+    }
+   },
    "outputs": [],
+   "source": [
+    "\n",
+    "# 4. Final cleanup\n",
+    "\n",
+    "# Reset the display.max_rows option to the original default\n",
+    "pd.reset_option(\"display.max_rows\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "3d2d7e9a-a8c5-43e3-9fb3-f8b7cf5b6e87",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-10-28T21:18:58.619352Z",
+     "iopub.status.busy": "2024-10-28T21:18:58.619231Z",
+     "iopub.status.idle": "2024-10-28T21:18:58.788090Z",
+     "shell.execute_reply": "2024-10-28T21:18:58.787565Z",
+     "shell.execute_reply.started": "2024-10-28T21:18:58.619340Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0oAAANnCAYAAAAP6KgFAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAADD10lEQVR4nOzdeXxMV/8H8M+dNZNEJJZEEhGE2JOonUpi32Jvtai16EOq9aPaomrfSlUfpdrad0URu6BCixYVS4vQ2vct1kkyy/n94Zmp2ZIJiYnxeb9eebXuPffOuffcuXO/92ySEEKAiIiIiIiIzGSuzgAREREREVFew0CJiIiIiIjICgMlIiIiIiIiKwyUiIiIiIiIrDBQIiIiIiIissJAiYiIiIiIyAoDJSIiIiIiIisMlIiIiIiIiKwwUCIiIiIiIrLCQMlJkiRl+Tdy5Mhc+/xdu3ZBkiTs2rXLvGzTpk0OP1OSJLz//vvP/bnHjh2DJElQKpW4evXqc+/PWbGxsYiNjX1hn5cb5s+fb742ni43EyEESpUqBUmSbI7VuvzOnTtnca0plUoULFgQ1apVw//93//hzz//zPH837lzB2+//Tb8/f0hSRLatGnjMG1sbCwqVqyY5T63bt2Kxo0bIygoCGq1GkFBQYiNjcXEiRMt0j169AiTJk1CZGQkfHx8kC9fPoSFhaFDhw5ISkoCABQvXtyp7+X8+fMBAPfv38e4ceNQtWpV+Pj4QK1Wo3jx4ujZsyf++OOPZz5Pzyuv5sseIQSWLl2K+vXrw8/PD2q1GiVLlkR8fDwuXrxok97Z6+Jl9fjxY4wcOdLu99v0/T937twLz1dOyu59wPS9k8lkyJcvH0qVKoU333wTq1atgtFotNmmePHi6N69u8Wyw4cPIyYmBvnz54ckSZg2bRoAYMeOHahatSq8vLwgSRLWrl2bcweaw8aPH5+t/N2+fRtDhgxB+fLl4eXlhfz586Ns2bLo0qULjh49mq3Ptve88DKy/t2TyWQoWLAgmjdvjn379rk6e3mG9XnK7C+v3Y/27t2LkSNHIjU11dVZcUjh6gy8LBx9KfV6Pbp27YrLly+jefPmufb5r732Gvbt24fy5cubl23atAkzZszI1QBt9uzZAJ4c58KFC/HJJ5/k2me5q3z58mHOnDk2wVBSUhL+/vtv5MuXz+l99e/fH506dYLRaERqaioOHz6MuXPnYvr06ZgwYQIGDx6cY/keM2YM1qxZg7lz5yIsLAwFChR4rv3NmjULffv2Rfv27fHNN9+gQIECuHjxIvbu3YtVq1bh008/BQAYDAY0btwYx44dw+DBg1G9enUAwOnTp7F+/Xrs2bMHMTExWLNmDdLT0837nz17NubMmYMtW7Ygf/785uVhYWH4+++/0bhxY9y4cQP/+c9/MGrUKHh7e+PcuXP48ccfUaVKFaSmplps9yLk1XzZYzQa0alTJ6xYsQIdO3bE/PnzkT9/fhw9ehSTJ0/G0qVLsWHDBtSpU8fVWX1hHj9+jFGjRgGAzfe7RYsW2LdvHwIDA12Qs5yT3ftAyZIlsWTJEgBPXnicPXsWa9euxZtvvom6deti/fr1FtfzmjVr4OPjY7GPnj174tGjR1i+fDn8/PxQvHhxCCHQoUMHhIeHIyEhAV5eXihTpkzOH3AOGT9+PN54441MA0uThw8fombNmnj48CEGDx6MyMhIaLVapKSk4KeffkJycjIiIiKc/mx7zwsvM9PvnsFgwJ9//olRo0ahXr162LdvHypXruzq7LlcYGCgzTNqv379cO/ePfN38em0ecnevXsxatQodO/eHb6+vq7Ojn2Cnkv//v0FAPHdd9+98M+Oj48XjooQgIiPj3+u/aelpYmCBQuKyMhIERwcLMLDw59rf9kRExMjYmJiXtjn5YZ58+YJAKJXr15Co9GIe/fuWax/5513RK1atUSFChVsjtW6/M6ePSsAiMmTJ9t8zuPHj0XTpk0FALFp06Ycy3/Dhg1FuXLlnEobExMjKlSokGmaYsWKiejoaLvrDAaD+f937twpAIi5c+dmmfZpI0aMEADEzZs3LZbr9XpRqVIl4ePjI44dO2Z3202bNolHjx5lmv+cllfz5cj48eMFADFx4kSbddeuXROhoaEiICBA3L1717zcmeviRdDr9SItLS3H93vz5k0BQIwYMSLH951X5NR9YO7cuQKA6NChQ5b7USgUom/fvhbLLl26JACISZMmOZUXZ2RkZAidTpdj+3ual5eX6Natm1NpTedm586ddtc7uue5O0e/ezt27DD/tjry+PFjYTQaczuLQojcvY6eVU7fex8/fpxj+3ra5MmTBQBx9uzZXNl/TmDTu+ewaNEiTJ8+He+++y769OljsS4jIwNjx45F2bJloVarUbhwYfTo0QM3b960SFe8eHHExcVhy5YteO2116DRaFC2bFnMnTvXIp11VXr37t0xY8YMAMi0WnXRokUoV64cPD09ERkZiQ0bNjh9fGvXrsXt27fRq1cvdOvWDSkpKfjll19s0jl7DADwyy+/oFatWvDw8EBwcDCGDx+O2bNnO1Ul7Ow5tTZt2jRIkoQzZ87YrPvkk0+gUqlw69YtAE+afMTFxcHf39/cNKxFixa4dOlSpp+RmY4dOwIAli1bZl527949rF69Gj179nzm/ZpoNBrMmTMHSqUSkydPzjL9nTt30K9fPwQHB0OlUqFkyZIYNmyYuXbGVI2/fft2nDhxItPmg9lx+/Zth2+zZDKZRTrA8Zuvp9M6Y+3atTh27BiGDBnisBlYs2bN4Onpaf73L7/8ggYNGiBfvnzw9PRE7dq1sXHjRottTE2rdu7cid69e6NgwYLw8fFB165d8ejRI1y7dg0dOnSAr68vAgMD8dFHH0Gn0z1zvs6cOYMePXqgdOnS8PT0RHBwMFq2bIljx45ZbGO6VyxduhSffPIJAgMD4e3tjZYtW+L69et48OAB+vTpg0KFCqFQoULo0aMHHj58mOk5zMjIwOTJk1GuXDl8/PHHNusDAgIwYcIEXL9+HXPmzLFZv2fPHtSsWRMajcb8vTcYDBZpvv32W0RGRsLb2xv58uVD2bJlMXToUIs0165dw3vvvYeiRYtCpVKhRIkSGDVqFPR6vTmN6fr94osvMHbsWJQoUQJqtRo//vgjVCoVhg8fbpO/kydPQpIk/Pe//wUA3Lx5E/369UP58uXh7e0Nf39/1K9fH3v27LH4nMKFCwMARo0aZf6emJqROWp6N3fuXERGRsLDwwMFChRA27ZtceLECYs03bt3h7e3N86cOYPmzZvD29sbISEhGDRokEUtqrPnzZ4XfR/o0aMHmjdvjpUrV+L8+fPm5U83vTOdM71ej2+//daiWXvRokUBPLlnS5KE4sWLm/dx+vRpdOrUyXzfLleunPn30cT0vVi0aBEGDRqE4OBgqNVq8+/C9u3b0aBBA/j4+MDT0xN16tTBjh07LPYxcuRISJKEP//8Ex07dkT+/PkREBCAnj174t69e+Z0kiTh0aNHWLBggfkYMmtKnt173smTJ9GxY0cEBARArVajWLFi6Nq1q7nsHDW9O3jwIFq1aoUCBQrAw8MDlStXxo8//miRxlQGP//8M/r27YtChQqhYMGCaNeuHa5cuWKTt6VLl6JWrVrw9vaGt7c3oqKibO4Bzpzb7KhZsyYAmK8jU563bduGnj17onDhwvD09ER6ejqMRiO++OIL83ODv78/unbtavObLoTA+PHjERoaCg8PD1StWhWJiYk23QAyu46cuW8A/363Jk+ejEmTJqF48eLQaDSIjY1FSkoKdDodPv30UwQFBSF//vxo27Ytbty48czny2TUqFGoUaMGChQoAB8fH7z22muYM2cOhBAW6UzPdD/99BMqV64MDw8Pc835n3/+icaNG8PT0xOFCxdGfHw8Nm7caPd6y6rcR44caW4FU6JECZt7zM6dOxEbG4uCBQtCo9GgWLFiaN++PR4/fvzc5yJbXB2pvaz++OMPodFoRLVq1WzeVBoMBtG0aVPh5eUlRo0aJRITE8Xs2bNFcHCwKF++vEVkHhoaKooWLSrKly8vFi5cKLZu3SrefPNNAUAkJSWZ0/38888CgPj555+FEEKcOXNGvPHGGwKA2Ldvn/nPlBcAonjx4qJ69erixx9/FJs2bRKxsbFCoVCIv//+26ljbNSokVCr1eLOnTvizJkzQpIk0b17d5t0zh7DkSNHhIeHh4iIiBDLly8XCQkJonnz5qJ48eI2bxSsa5Syc06t3bx5U6hUKjFs2DCL5Xq9XgQFBYl27doJIYR4+PChKFiwoKhatar48ccfRVJSklixYoX4z3/+I/766y+nztnTTDVKBw4cEF26dBHVq1c3r/v222+Fl5eXuH///nPXKJnUrFlTqNXqTN9sabVaERERIby8vMSUKVPEtm3bxPDhw4VCoRDNmzcXQjypSdy3b5+oXLmyKFmypPnasq4Re5ozb68aNmwoFAqFGDFihEhOThZ6vd5uurNnzwqlUinCw8PF4sWLxZUrVzLdr4mjGqU+ffoIAOLEiRNO7WfXrl1CqVSKKlWqiBUrVoi1a9eKxo0bC0mSxPLly83pTOVbokQJMWjQILFt2zYxadIkIZfLRceOHcVrr70mxo4dKxITE8Unn3wiAIgvv/zymfOVlJQkBg0aJFatWiWSkpLEmjVrRJs2bYRGoxEnT540pzPdK0JDQ0X37t3Fli1bxKxZs4S3t7eoV6+eaNSokfjoo48s8tu/f/9MP3vv3r0CgPjkk08cpnnw4IGQyWSiSZMm5mUxMTGiYMGCIigoSPz3v/8VW7duFR988IHN9b1s2TIBQPTv319s27ZNbN++XcyaNUt88MEH5jRXr14VISEhIjQ0VHz33Xdi+/btYsyYMUKtVlvcl0zfleDgYFGvXj2xatUqsW3bNnH27FnRtm1bERISYvOG/uOPPxYqlUrcunVLCCHEyZMnRd++fcXy5cvFrl27xIYNG8S7774rZDKZ+R6clpYmtmzZIgCId9991/w9OXPmjBDi3+vj6fuaqVauY8eOYuPGjWLhwoWiZMmSIn/+/CIlJcWcrlu3bkKlUoly5cqJKVOmiO3bt4vPP/9cSJIkRo0ala3zZo+r7gOzZs0SAMSiRYvMy0JDQ801Lzdu3BD79u0TAMQbb7xh/syLFy+Kn376yXys+/btE3/88YcQQog///xT5M+fX1SqVEksXLhQbNu2TQwaNEjIZDIxcuRI8+eYvhfBwcHijTfeEAkJCWLDhg3i9u3bYtGiRUKSJNGmTRvx008/ifXr14u4uDghl8vF9u3bzfsw3WPKlCkjPv/8c5GYmCimTp0q1Gq16NGjhzndvn37hEajEc2bNzcfw59//unwvPzyyy8CgKhWrZpYs2aN+Tq0Jzk5WXh7e4vixYuLWbNmiR07dojFixeLDh06iPv371scq+laFeJJTb1KpRJ169YVK1asEFu2bBHdu3cXAMS8efPM6UzXbcmSJUX//v3F1q1bxezZs4Wfn5+oV6+eRV6GDx8uAIh27dqJlStXim3btompU6eK4cOHm9M4e27tcfS7d+TIEQFAdOrUySLPwcHBok+fPmLz5s1i1apVQq/Xm++z77//vvleWLhwYRESEmLxWzFkyBABQPTp00ds2bJF/PDDD6JYsWIiMDDQ4vc5s+vImfvG08cVGhoqWrZsKTZs2CAWL14sAgICRHh4uOjSpYvo2bOn2Lx5s/ne3bJly0zPlTV738Xu3buLOXPmiMTERJGYmCjGjBkjNBqNxT1FiCffycDAQFGyZEkxd+5c8fPPP4vff/9dXLlyRRQsWFAUK1ZMzJ8/X2zatEl06dLF/Az39DE6U+4XL140t8r66aefLO4xZ8+eFR4eHqJRo0Zi7dq1YteuXWLJkiWiS5cuFq0WXgQGSs/g5s2bIjQ0VBQuXFhcuHDBZr3px2v16tUWyw8cOCAAiJkzZ5qXhYaGCg8PD3H+/HnzMq1WKwoUKCDee+898zJ7N76smt4FBASYb5xCPGkeI5PJxIQJE7I8xnPnzgmZTCbefvtt87KYmBjzw/3TnD2GN998U3h5eVncnAwGgyhfvnyWgVJ2zqk97dq1E0WLFrV4QNq0aZMAINavXy+EEOLgwYMCgFi7dm2m+3LW04GSqfyOHz8uhBCiWrVq5oe7nAqU3nrrLQFAXL9+3WEa04PKjz/+aLF80qRJAoDYtm2beVl2qu6dSXvmzBlRsWJFAUAAEBqNRjRo0EB88803IiMjwyLtnDlzhLe3tzltYGCg6Nq1q9i9e7fD/TsKlEzNEp1telWzZk3h7+8vHjx4YF6m1+tFxYoVRdGiRc3NOUzlax1ktGnTRgAQU6dOtVgeFRUlXnvttWfOlzW9Xi8yMjJE6dKlxf/93/+Zl5uuNesf1gEDBggANg/Rbdq0EQUKFMj0s5YvXy4AiFmzZmWaLiAgwKKZVkxMjAAg1q1bZ5Gud+/eQiaTme8Z77//vvD19c103++9957w9va2uM8IIcSUKVMEAPODqOm7EhYWZnNdJSQk2Fznphcm7du3d/jZer1e6HQ60aBBA9G2bVvz8sya3lkHSnfv3jU/PD/twoULQq1Wmx/6hHgSKNn7njZv3lyUKVPG/G9nzps9rroPbN682ab53NOBkon1/U8Ix/fAJk2aiKJFi9oEcO+//77w8PAQd+7cEUL8+72wbv776NEjUaBAAZvvi8FgEJGRkRYvuEz3mC+++MIibb9+/YSHh4dFU6/sNL0TQojRo0cLlUplvueVKFFC/Oc//xFHjhyxSFe/fn3h6+srbty44XBf9p4XypYtKypXrmzzIi0uLk4EBgaafxtN122/fv0s0n3xxRcCgLh69aoQQoh//vlHyOVy0blzZ4f5yM65tcdU5pMmTRI6nU6kpaWJQ4cOiWrVqgkAYuPGjRZ57tq1q8X2J06csHssv/32mwAghg4dKoQQ4s6dO0KtVou33nrLIp0paLcXKDlqRv40R/cN03FFRkZaPJNMmzZNABCtWrWy2I/p3p3ZSwprWX0XDQaD0Ol0YvTo0aJgwYIW125oaKiQy+Xi1KlTFtsMHjxYSJJkE/Q3adLE4nrLTrk7anq3atUqAUAkJyc7fcy5hU3vsslgMODtt9/GpUuXsGLFCoSEhNik2bBhA3x9fdGyZUvo9XrzX1RUFIoUKWJTPRkVFYVixYqZ/+3h4YHw8HCL5gnPol69ehYDBQQEBMDf39+p/c6bNw9Go9GiaZipg+2KFSts0jtzDElJSahfvz4KFSpkXiaTydChQ4cs85Pdc2qtR48euHTpErZv325xjEWKFEGzZs0AAKVKlYKfnx8++eQTzJo1C3/99VeW+XJWTEwMwsLCMHfuXBw7dgwHDhzIkWZ3TxNW1ef27Ny5E15eXnjjjTcslpuavjxPc4ishIWF4ciRI0hKSsKoUaPQsGFDHDhwAO+//z5q1aqFtLQ0c9qePXvi0qVLWLp0KT744AOEhIRg8eLFiImJcap54bN69OgRfvvtN7zxxhvw9vY2L5fL5ejSpQsuXbqEU6dOWWwTFxdn8e9y5coBeNKZ33r583yn9Xo9xo8fj/Lly0OlUkGhUEClUuH06dM2Tbeym687d+5k2fzOGUIISJJksSxfvnxo1aqVxTLTgCS7d+8GAFSvXh2pqano2LEj1q1bZ24K+7QNGzagXr16CAoKsrgHmL6/ptEQTVq1agWlUmmxrFmzZihSpAjmzZtnXrZ161ZcuXLF5vs4a9YsvPbaa/Dw8IBCoYBSqcSOHTvsnmtn7Nu3D1qt1maEt5CQENSvX9/muydJElq2bGmxLCIiwuIacua82eOq+4Az96jsSEtLw44dO9C2bVt4enpaXBfNmzdHWloa9u/fb7FN+/btLf69d+9e3LlzB926dbPY3mg0omnTpjhw4AAePXpksY319RwREYG0tLTnah41fPhwXLhwAXPnzsV7770Hb29vzJo1C1WqVDE32378+DGSkpLQoUMHc7NPZ5w5cwYnT55E586dAcDmPF29etXmvmbvGIF/m7slJibCYDAgPj7e4ec+y7m155NPPoFSqYSHhweqVKmCCxcu4LvvvrMZQMu6bH/++WcAsPnOVa9eHeXKlTNf5/v370d6errNs0jNmjUtmnhm9lkm2blvNG/e3KJZZWb3aAC4cOGC3c901s6dO9GwYUPkz58fcrkcSqUSn3/+OW7fvm1z7UZERCA8PNxiWVJSEipWrGgzSIipe4FJTpR7VFQUVCoV+vTpgwULFuCff/55jiN/PgyUsunjjz/Gjh07MGnSJNSrV89umuvXryM1NRUqlQpKpdLi79q1azY/ZgULFrTZh1qthlarfa68Put+jUYj5s+fj6CgIPOoW6mpqWjYsCG8vLzs9kFw5rNu376NgIAAm3T2llnL7jm11qxZMwQGBpofkO7evYuEhAR07doVcrkcAJA/f34kJSUhKioKQ4cORYUKFRAUFIQRI0ZY9C15FpIkoUePHli8eDFmzZqF8PBw1K1b97n2ae38+fNQq9WZjkp1+/ZtFClSxOZh1t/fHwqFwtxWPrfIZDJER0fj888/R0JCAq5cuYK33noLhw4dsunTlj9/fnTs2BFff/01fvvtNxw9ehQBAQEYNmxYtoYSNQXwZ8+ezTLt3bt3IYSw21cgKCgIAGzOkfX5VqlUDpc/HQxmJ18AMHDgQAwfPhxt2rTB+vXr8dtvv+HAgQPmEbKsZSdfACzyZs2ZvD569Ai3bt2yeXlk7/tdpEgRAP+eyy5dumDu3Lk4f/482rdvD39/f9SoUQOJiYnmba5fv47169fbfP8rVKgAADb3AHtlqFAo0KVLF6xZs8Z8Dc2fPx+BgYFo0qSJOd3UqVPRt29f1KhRA6tXr8b+/ftx4MABNG3a9Jnvy5n1QwkKCrK5rjw9PeHh4WGxTK1WW5STM+fNUV5ccR8wPWSbvkvP6/bt29Dr9Zg+fbrNdWF6iM7qurh+/ToA4I033rDZx6RJkyCEwJ07dyy2sf69U6vVAPDcv9kBAQHo0aMHZs2ahaNHjyIpKQkqlQoffvghgCf3J4PBYO6v5SzTMX700Uc2x9ivXz8Atucpq2M09Q3OLC/Pcm7t+fDDD3HgwAEcOnQIf//9N65evWrTLxywLVtnv3Om/2bn+cTePrN738jJe3RWfv/9dzRu3BgA8MMPP+DXX3/FgQMHMGzYMAC2166943P2GS4nyj0sLAzbt2+Hv78/4uPjERYWhrCwMHz99dfOH3QO4fDg2bBs2TJMnToVb731FgYNGuQwnanz45YtW+yuz85w0K6wfft28w+avQBo//79+Ouvv7I99GjBggXNX6CnXbt2Lcttn/ecmmoE/vvf/yI1NRVLly5Feno6evToYZGuUqVKWL58OYQQOHr0KObPn4/Ro0dDo9GYh69+Vt27d8fnn3+OWbNmYdy4cc+1L2uXL1/GoUOHEBMTA4XC8de6YMGC+O2332ze/N+4cQN6vd6itu9F8PLywpAhQ7BixQocP34807QVKlTA22+/jWnTpiElJcU8bHhWmjRpgu+//x5r167Nsgz9/Pwgk8nszhlm6sicU+coO/kCgMWLF6Nr164YP368xfJbt27l+rCqVapUgZ+fHxISEjBhwgSbB2wASEhIgNFoRKNGjSyWZ/adf/r+0qNHD/To0QOPHj3C7t27MWLECMTFxSElJQWhoaEoVKgQIiIiHH53rB++7eXR9DmTJ0/G8uXL8dZbbyEhIQEDBgwwvzABnpzr2NhYfPvttxbbPnjwwO4+nWE6VkfX1rNeV1mdN0d5ccV9ICEhAZIkITo6Okf25+fnZ763O6rZKFGihMW/ra8L07FOnz7dPEiANWde5uWG6OhoNG7cGGvXrsWNGzdQoEAByOXybA8uZDrGIUOGoF27dnbTZHeodVON1qVLl+y2rHn6c5/33BYtWhRVq1bNMp112T79nbMO6J7+zpnSObpX2atVsnd/yY37Rk5Zvnw5lEolNmzYYPECxtFcX/aOz9lnuJwq97p166Ju3bowGAw4ePAgpk+fjgEDBiAgIABvv/12ltvnFNYoOeno0aPo1asXKlasaLdG5WlxcXG4ffs2DAYDqlatavOXU3M/5NRbLGtz5syBTCbD2rVr8fPPP1v8LVq0CADsjmiXlZiYGOzcudPizZXRaMTKlSuz3DYnzmmPHj2QlpaGZcuWYf78+ahVqxbKli1rN60kSYiMjMRXX30FX1/fHJn4Mzg4GIMHD0bLli3RrVu3596fiVarRa9evaDX6+2OSPa0Bg0a4OHDhzY3x4ULF5rX5xZHExabmiQ8XWOTkZFhN+3Jkyct0jqjdevWqFSpEiZMmOAwGNu6dSseP34MLy8v1KhRAz/99JPF98poNGLx4sUoWrSoTXOEZ5WdfAFPrknTd95k48aNuHz5co7kJzMqlQqDBw/GiRMn7DZ9vHHjBoYMGYKAgAD06tXLYt2DBw+QkJBgsWzp0qXm2kVrXl5eaNasGYYNG4aMjAzzZMpxcXE4fvw4wsLC7N4DnL0mypUrhxo1amDevHkOX5jYO9dHjx61maskO/fgWrVqQaPRYPHixRbLL126hJ07dz73d8/RebPHFfeBefPmYfPmzejYsaNFM+3n4enpiXr16uHw4cOIiIiwe13Ye9n3tDp16sDX1xd//fWX3e2rVq1qfqOfHdlpFXL9+nW7k/EaDAacPn0anp6e8PX1hUajQUxMDFauXOl0M0vgSRBUunRpHDlyxOExZvcFbuPGjSGXy22Cgqfl1rl1Vv369QHA5jt34MABnDhxwnyd16hRA2q12qZbwf79+7PVXNrZ+4YrSJIEhUJh8UJIq9Wan+mcERMTg+PHj9t0S1i+fLnFv7NT7s7cQ+VyOWrUqGEeyfJFT8TOGiUn3L17F23atEF6ejo++eQTm+F4TQoXLoywsDC8/fbbWLJkCZo3b44PP/wQ1atXh1KpxKVLl/Dzzz+jdevWaNu27XPnq1KlSgCASZMmoVmzZpDL5YiIiHiuG8/t27exbt06NGnSBK1bt7ab5quvvsLChQsxYcIEmz4AmRk2bBjWr1+PBg0aYNiwYdBoNJg1a5a5rWpmwz7nxDktW7YsatWqhQkTJuDixYv4/vvvLdZv2LABM2fORJs2bVCyZEkIIfDTTz8hNTXV4i15gwYNkJSUZDEksbMmTpzodFp7b3QuXLiA/fv3w2g04t69e+YJZ8+fP48vv/zSXLXuSNeuXTFjxgx069YN586dQ6VKlfDLL79g/PjxaN68ORo2bJjtYzK5f/8+Vq1aZbO8cOHCiImJQYUKFdCgQQM0a9YMYWFhSEtLw2+//YYvv/wSAQEBePfddwE8aVf+4YcfonPnzqhduzYKFiyIGzduYNmyZdiyZQu6du2araYncrkca9asQePGjVGrVi307dsX9erVg5eXF86fP49Vq1Zh/fr1uHv3LgBgwoQJaNSoEerVq4ePPvoIKpUKM2fOxPHjx7Fs2TKHNRXZld18xcXFYf78+ShbtiwiIiJw6NAhTJ48OdvNcJ7VJ598giNHjpj/+9Zbb1lMOPvgwQNs2LDBZnLcggULom/fvrhw4QLCw8OxadMm/PDDD+jbt6/5gbl3797QaDSoU6cOAgMDce3aNUyYMAH58+dHtWrVAACjR49GYmIiateujQ8++ABlypRBWloazp07h02bNmHWrFlOn4uePXvivffew5UrV1C7dm2bFy1xcXEYM2YMRowYgZiYGJw6dQqjR49GiRIlLL73+fLlQ2hoKNatW4cGDRqgQIECKFSokN030L6+vhg+fDiGDh2Krl27omPHjrh9+zZGjRoFDw8PjBgxIjvF4fR5syc37wNardbcL0ir1eKff/7B2rVrsWHDBsTExGDWrFnPvG97vv76a7z++uuoW7cu+vbti+LFi+PBgwc4c+YM1q9fj507d2a6vbe3N6ZPn45u3brhzp07eOONN+Dv74+bN2/iyJEjuHnzZqbBgCOVKlXCrl27sH79egQGBiJfvnwOX+gtWrQI3333HTp16oRq1aohf/78uHTpEmbPno0///wTn3/+ufl3ferUqXj99ddRo0YNfPrppyhVqhSuX7+OhIQEfPfddw4Dnu+++w7NmjVDkyZN0L17dwQHB+POnTs4ceIE/vjjD6deWD6tePHiGDp0KMaMGQOtVmseLv2vv/7CrVu3zJNn58a5dVaZMmXQp08fTJ8+HTKZDM2aNcO5c+cwfPhwhISE4P/+7/8APGnqNnDgQEyYMAF+fn5o27YtLl26hFGjRiEwMNDpKSmcvW+4QosWLTB16lR06tQJffr0we3btzFlyhSbwC4zAwYMwNy5c9GsWTOMHj0aAQEBWLp0qfkFpuk8ZafcTc+xX3/9Nbp16walUokyZcpgyZIl2LlzJ1q0aIFixYohLS3N/IL+ee5Pz8RFg0i8VEyjnGT19/QINzqdTkyZMkVERkYKDw8P4e3tLcqWLSvee+89cfr0aXO60NBQ0aJFC5vPtB71zd4oNunp6aJXr16icOHCQpIki5FDYGfUINPnZTYSj2nUlcxGfjONmGQagc7ZYxBCiD179ogaNWoItVotihQpIgYPHmweaSk1NTXTbZ09p5n5/vvvzSOuWY8gc/LkSdGxY0cRFhYmNBqNyJ8/v6hevbqYP3++zXE589V5etS7zFiPevfo0SMBQAwaNMi8zDRKjulPLpcLPz8/UaVKFTFgwIBMh561dvv2bfGf//xHBAYGCoVCIUJDQ8WQIUNsRl/L7mhXjr4XpmP77rvvRLt27UTJkiWFp6enUKlUIiwsTPznP/8RFy9eNO/r4sWL4rPPPhN16tQRRYoUEQqFQuTLl0/UqFFDTJ8+3eGw4o5GvTNJTU0VY8aMEa+99prw9vYWSqVSFCtWTLzzzjvi119/tUi7Z88eUb9+feHl5SU0Go2oWbOmeXREE0fl6ygf3bp1E15eXs+cr7t374p3331X+Pv7C09PT/H666+LPXv2OLxXrFy58rnya4/RaBRLliwRsbGxwtfXV6hUKlGiRAnRt29fm9HohPj3Gtq1a5eoWrWqUKvVIjAwUAwdOtRi9K0FCxaIevXqiYCAAKFSqURQUJDo0KGDOHr0qMX+bt68KT744ANRokQJoVQqRYECBUSVKlXEsGHDxMOHD4UQzo0Qee/ePaHRaAQA8cMPP9isT09PFx999JEIDg4WHh4e4rXXXhNr164V3bp1E6GhoRZpt2/fLipXrizUarXF74C94cGFEGL27NkiIiJCqFQqkT9/ftG6dWub76+ja8VUVtk9b/a8iPuAl5eXKFmypHjjjTfEypUr7U6c+ryj3pnW9ezZUwQHBwulUikKFy4sateuLcaOHWtO4+h7YZKUlCRatGghChQoIJRKpQgODhYtWrSwSO/ou2KvrJOTk0WdOnWEp6enzchp1v766y8xaNAgUbVqVVG4cGGhUCiEn5+fiImJsRhK/en0b775pihYsKBQqVSiWLFionv37uays/e8IMSTYbU7dOgg/P39hVKpFEWKFBH169e3GM3S0X3C0T4XLlwoqlWrZv5Nrly5ssVw486eW3uc+S5nlmchnoy0NmnSJBEeHi6USqUoVKiQeOeddyx+c4R4cm8bO3asKFq0qFCpVCIiIkJs2LBBREZGWoxYl9l15Ox9w9FxZffenRl739u5c+eKMmXKCLVaLUqWLCkmTJgg5syZY3PtOnqmE0KI48ePi4YNGwoPDw9RoEAB8e6774oFCxYIADYjNDpb7kOGDBFBQUFCJpOZr7F9+/aJtm3bitDQUKFWq0XBggVFTEyMSEhIcPoc5BRJiBwehoYomxo3boxz584hJSXF1VnJEw4fPozXXnsNM2bMMHe0JSIiohfn7NmzKFu2LEaMGOHUJM6vqj59+mDZsmW4fft2rjaldBU2vaMXauDAgahcuTJCQkJw584dLFmyBImJiVn2+3oVXLp0CcnJyRg3bhw8PT3Rpk0bV2eJiIjI7R05cgTLli1D7dq14ePjg1OnTuGLL76Aj4+PuVk4PWkCHRQUhJIlS+Lhw4fYsGEDZs+ejc8++8wtgySAgRK9YAaDAZ9//jmuXbsGSZJQvnx5LFq0CO+8846rs+Zys2fPxsSJExEREYGEhIQcG0KXiIiIHPPy8sLBgwcxZ84cpKamIn/+/IiNjcW4ceNcNuphXqRUKjF58mRcunQJer0epUuXxtSpU81D2LsjNr0jIiIiIiKywuHBiYiIiIiIrDBQIiIiIiIissJAiYiwa9cuSJJkdx6kZ/XXX39h5MiROHfuXI7tMy8xGAyYOnUqmjZtiqJFi8LT0xPlypXDp59+itTUVLvbTJ8+HWXLloVarUaJEiUwatQo6HQ6izQ//fQTOnbsiFKlSkGj0aB48eLo3LkzTp8+nWl+tFotwsPDIUkSpkyZYrP+s88+Q1xcHIKDgyFJErp37+5wX//88w/atWsHX19feHt7o1GjRjaT/F29ehWfffYZatWqhUKFCsHHxwdVqlTB999/D4PBkGleZ8+eDUmS4O3tnWk6VyhevHim5wbI/rE/fPgQAwYMQFBQEDw8PBAVFWUzSeOzXE8mf/31F9RqNSRJwsGDBy3WXbp0CQMGDEBMTAx8fX0hSRLmz5/vcF/bt29HrVq14OnpiUKFCqF79+64ceOGRZpDhw4hPj4elSpVQr58+RAQEICGDRs6nLNo9erVqFOnDgoUKABfX19Ur149WxNd6nQ6lC1b1mIeuvnz50OSpFy9v0iShJEjR760+09JSYFKpXrhE3QSuRMGSkSUK/766y+MGjXKbQMlrVaLkSNHIjQ0FNOmTcOmTZvQu3dvfP/996hTp47NTOPjxo3Dhx9+iHbt2mHr1q3o168fxo8fj/j4eIt0kyZNwuPHjzFs2DBs2bIFY8eONQ8Z/+effzrMz/Dhw82TN9vz1Vdf4fbt22jVqlWmoxPdvHkTdevWRUpKCubOnYsff/wRaWlpiI2NxalTp8zpDh06hIULF6JBgwZYuHAhVq9ejZiYGPTt2xe9e/d2uP/Lly/jo48+eqkHK8nusbdr1w4LFizAiBEjsHnzZlSrVg0dO3bE0qVLzWmyez2ZGAwG9OzZE4UKFbK7/syZM1iyZAlUKhWaN2+e6XElJSWhWbNmCAgIwLp16/D1119j+/btaNCgAdLT083pli1bht9//x09e/bEunXrMHv2bKjVavP5eNrcuXPxxhtvIDAwEEuWLMHy5csRFhaGrl274quvvso0PyYzZ87E3bt30b9/f/OyFi1aYN++fQgMDHRqH3nRvn370KtXr1zbf3h4ODp37myeWJWInsELn7mJiPKcrCZjfBYrV660O0Ghu9Dr9eLWrVs2y03H/fREkbdu3RIeHh6iT58+FmnHjRsnJEmymHD0+vXrNvu8fPmyUCqV4t1337Wbl99++02oVCrzZ9uboPHpyT69vLwcTjw9ePBgoVQqxblz58zL7t27JwoVKiQ6dOhgXnbnzh2RkZFhs318fLwAIC5cuGB3/3FxcaJly5YOJ1V1tawm5RYie8e+ceNGAUAsXbrUIm2jRo1EUFCQeQLl7FxPT5s8ebIIDg4WX3/9td1JKZ8u9wMHDggANhOCmlSrVk2UL1/eYjLgX3/9VQAQM2fONC+zd43q9XoREREhwsLCLJbXqVNHhIaGWuTDaDSKsmXLioiICLv5eJpOpxPBwcHi008/zTJtTgMgRowY8cI/NycdPHhQALCZVJuInMMaJSIyS0tLw8CBA1GkSBFoNBrExMTg8OHDNukOHjyIVq1aoUCBAvDw8EDlypXx448/mtfPnz8fb775JgCgXr16kCTJ3ORnxowZkMlkFs15vvzyS0iSZFG7YjQa4efnh0GDBpmXZWRkYOzYsebma4ULF0aPHj1w8+ZNmzyuWLECtWrVgpeXF7y9vdGkSRObY+nevTu8vb1x5swZNG/eHN7e3ggJCcGgQYMs3qDbI5fLUbBgQZvl1atXBwBcvHjRvGzLli1IS0tDjx49LNL26NEDQgisXbvWvMzf399mn0FBQShatKjFPp8+Jz179kR8fDyqVq3qML8ymXO3+zVr1qB+/foIDQ01L/Px8UG7du2wfv166PV6AICfnx+USqXN9qbjv3Tpks26xYsXIykpCTNnznQqLyYHDx7E22+/jeLFi5ubI3bs2BHnz5+3SGdqjvXzzz+jb9++KFSoEAoWLIh27drhypUrFml1Oh0+/vhjFClSBJ6ennj99dfx+++/O5Wf7Bz7mjVr4O3tbf4+mPTo0QNXrlzBb7/9BiB715PJ6dOn8fnnn2PmzJnw8fGxm1dny/3y5cs4cOAAunTpAoXi35lDateujfDwcKxZs8a8zN41KpfLUaVKFZt8KpVKeHt7W+RDkiT4+PjAw8Mjy3wlJCTg8uXL6NKli8Vye03vYmNjUbFiRRw4cAB169aFp6cnSpYsiYkTJ8JoNFpsn5qaikGDBqFkyZJQq9Xw9/dH8+bNcfLkSYd5GTlyJCRJslluLy87d+5EbGwsChYsCI1Gg2LFiqF9+/Z4/PixxXkwNb07cuQIJEmyO6fg5s2bIUkSEhISzMtOnz6NTp06wd/fH2q1GuXKlcOMGTNstq1SpQrKlSuHWbNmOTwuInKMgRIRmQ0dOhT//PMPZs+ejdmzZ+PKlSuIjY3FP//8Y07z888/o06dOkhNTcWsWbOwbt06REVF4a233jL3fWjRogXGjx8PAJgxYwb27duHffv2oUWLFmjYsCGEENixY4d5n9u3b4dGo0FiYqJ52cGDB5GamoqGDRsCeBI4tW7dGhMnTkSnTp2wceNGTJw4EYmJiYiNjbVomjR+/Hh07NgR5cuXx48//ohFixbhwYMHqFu3Lv766y+LY9bpdGjVqhUaNGiAdevWoWfPnvjqq68wadKkZzqHpn4aFSpUMC87fvw4AKBSpUoWaQMDA1GoUCHzekf++ecfnD9/3mKfJqNHj8ajR48wZsyYZ8rv07RaLf7++29ERETYrIuIiIBWq7W4FuzZuXMnFAoFwsPDLZbfuHEDAwYMwMSJE1G0aNFs5evcuXMoU6YMpk2bhq1bt2LSpEm4evUqqlWrhlu3btmk79WrF5RKJZYuXYovvvgCu3btspmrrXfv3pgyZQq6du2KdevWoX379mjXrh3u3r2brbw9zd6xHz9+HOXKlbMIPgCYz3FWZW/vegIAIQR69eqFuLg4tGrV6pnz/HQ+n86XdV6zyqder8eePXts8tm/f3+cOHEC48aNw82bN3Hr1i1MmTIFhw4dwkcffZRlvjZu3Ah/f3+UL1/eqeO4du0aOnfujHfeeQcJCQlo1qwZhgwZgsWLF5vTPHjwAK+//jq+++479OjRA+vXr8esWbMQHh6Oq1evOvU5mTl37hxatGgBlUqFuXPnYsuWLZg4cSK8vLyQkZFhd5vIyEhUrlwZ8+bNs1k3f/58cyAHPGnWXK1aNRw/fhxffvklNmzYgBYtWuCDDz7AqFGjbLaPjY3F5s2bITgbDFH2ubZCi4jyAlPTu9dee00YjUbz8nPnzgmlUil69eplXla2bFlRuXJli+Y5QjxpUhUYGGhuYpNZ07uiRYuKnj17CiGESE9PF15eXuKTTz4RAMT58+eFEE+apSmVSvHw4UMhhBDLli0TAMTq1ast9mVqTmRqGnThwgWhUChE//79LdI9ePBAFClSxKL5WLdu3QQA8eOPP1qkbd68uShTpkzWJ87KpUuXREBAgKhatapFU6PevXsLtVptd5vw8HDRuHFjh/vU6XQiNjZW+Pj42DRnO3z4sFAqlWLLli1CCCHOnj3rsOnd0xw1vbt8+bIAICZMmGCzbunSpQKA2Lt3r8P9bt26VchkMvF///d/Nuvat28vateubb6+nqfpnV6vFw8fPhReXl7i66+/Ni+fN2+eACD69etnkf6LL74QAMTVq1eFEEKcOHFCALDJ55IlSwSALJve2ePo2EuXLi2aNGlik/7KlSsCgBg/frzDfTq6noQQYvr06cLPz09cu3ZNCPHvsVs3vXtaZk3vTMe+b98+m3V9+vQRKpXK4X6FEGLYsGECgFi7dq3NurVr14r8+fMLAAKA0Gg0YvHixZnuz6RcuXKiadOmNstNx3v27FnzspiYGAFA/PbbbxZpy5cvb1EGo0ePFgBEYmJipp8Nq6Z3I0aMEPYem6zzsmrVKgFAJCcnZ2v///3vfwUAcerUKfOyO3fuCLVaLQYNGmRe1qRJE1G0aFFx7949i/29//77wsPDQ9y5c8di+Q8//CAAiBMnTmSaHyKyxRolIjLr1KmTRdOS0NBQ1K5dGz///DOAJx3DT548ic6dOwN48hbZ9Ne8eXNcvXrVosO/Iw0aNMD27dsBAHv37sXjx48xcOBAFCpUyFyrZBp9y8vLCwCwYcMG+Pr6omXLlhafGxUVhSJFimDXrl0AgK1bt0Kv16Nr164W6Tw8PBATE2NOZyJJElq2bGmxLCIiwqZZV1bu3LmD5s2bQwiBFStW2DR5stdkJ6t1Qgi8++672LNnDxYuXIiQkBDzOr1ej549e+Ktt95CkyZNspXXrDxLXv/44w906NABNWvWxIQJEyzWrV69GuvXr8cPP/yQ6b4defjwIT755BOUKlUKCoUCCoUC3t7eePToEU6cOGGT3rqGxVRLYipT0/Vsuo5NOnToYFPz44zMjh14tvOZ2fV0/vx5DBkyBJMnT0ZAQEC285sZR/nJ7Bhmz56NcePGYdCgQWjdurXFui1btuCdd95Bu3btsHnzZiQmJqJXr17o3r273doTa1euXLHb1M+RIkWKmJsrmlh/nzdv3ozw8HBzbXVOi4qKgkqlQp8+fbBgwYIsa2FNOnfuDLVabTEq4bJly5Cenm5utpuWloYdO3agbdu28PT0tLkHp6WlYf/+/Rb7NZ2/y5cv58wBEr1CGCgRkVmRIkXsLrt9+zYA4Pr16wCAjz76CEql0uKvX79+AGC3KZS1hg0b4sKFCzh9+jS2b9+OypUrw9/fH/Xr18f27duh1Wqxd+9eiweZ69evIzU1FSqVyuazr127Zv5cUx6rVatmk27FihU2+fP09LTpK6FWq5GWlubsacPdu3fRqFEjXL58GYmJiShZsqTF+oIFCyItLc2if4LJnTt3UKBAAZvl4n9NqxYvXoz58+fbPIBOmzYN//zzD0aMGIHU1FSkpqbi/v37AJ48TKWmpmY5TLc1Pz8/SJJkLm/rfAKwm9fDhw+jUaNGKF26NDZt2gS1Wm1e9/DhQ8THx6N///4ICgoy59XUBCk1NTXT0fqAJwH8N998g169emHr1q34/fffceDAARQuXNjuaHDWfX1M+TGlNR2f9fWuUCjs9hPKTGbHbspLds9nVtdTfHw8KlasiPbt25vPp+naevjwIe7du5etYzDlE4DDvNrLJwDMmzcP7733Hvr06YPJkydbrBNCoGfPnoiOjsbcuXPRtGlTNGzYEP/973/RqVMn9O/fP8uy12q1TvVlsj6Op6nVaovr5ObNm9lu/pkdYWFh2L59O/z9/REfH4+wsDCEhYXh66+/znS7AgUKoFWrVli4cKH5uzt//nxUr17d3KTx9u3b0Ov1mD59us39zdQ0z/oeZzp/jkZOJCLHsv/qjIjc1rVr1+wuMz18mIYgHjJkCNq1a2d3H2XKlMnycxo0aADgSa1RYmIiGjVqZF7+2WefYffu3UhPT7cIlEwd87ds2WJ3n/ny5bPI46pVqywGJMgtd+/eRcOGDXH27Fns2LHDbh8PU9+kY8eOoUaNGublpgCvYsWKFulNQdK8efMwZ84cm/41wJM+Jffu3UPp0qVt1g0fPhzDhw/H4cOHERUV5fSxaDQalCpVCseOHbNZd+zYMWg0GpuH9sOHD6Nhw4YIDQ3Ftm3bkD9/fov1t27dwvXr1/Hll1/iyy+/tNmvn58fWrdubTGgxdPu3buHDRs2YMSIEfj000/Ny9PT083BRnaZrudr164hODjYvFyv19sNFBzJ6tiBJ2W/bNky6PV6i9oq0zm2Lntnrqfjx4/j/Pnz8PPzs1lXr1495M+fP8u5l6yZ8nHs2DGbYcSPHTtmk0/gSZDUq1cvdOvWDbNmzbKpdbp+/TquXr2K9957z2bbatWqYeHChTh37pzdvncmhQoVeuZydqRw4cJ2BxvJiingSE9PtwiI7b0cqlu3LurWrQuDwYCDBw9i+vTpGDBgAAICAvD22287/IwePXpg5cqVSExMRLFixXDgwAF8++235vV+fn6Qy+Xo0qWLzdQCJiVKlLD4t+n8ORpCnogcY6BERGbLli3DwIEDzQ8858+fx969e9G1a1cAT4Kg0qVL48iRI+bBGhyxfov/tMDAQJQvXx6rV6/GoUOHzPtq1KgR3nvvPUydOhU+Pj6oVq2aeZu4uDgsX74cBoPBItiw1qRJEygUCvz9999o37599k5ANpkeav/55x8kJiaicuXKdtM1bdoUHh4emD9/vkXeTaNltWnTxrxMCIHevXtj3rx55s7m9nz66ac2E6Neu3YNHTt2xH/+8x+89dZbKFWqVLaPqW3btpg2bRouXrxobur34MED/PTTT2jVqpXFw35ycjIaNmyIokWLIjEx0e6De5EiRcxN3Z42ceJEJCUlYfPmzZk+wEmSBCGETU3N7Nmzs11jZhIbGwsAWLJkCapUqWJe/uOPP5pH9cuKM8cOPDmfP/zwA1avXo233nrLvHzBggUICgqyuB6cvZ6WL19uU+O5ZcsWTJo0CbNmzco08HAkODgY1atXx+LFi/HRRx9BLpcDAPbv349Tp05hwIABFunnz5+PXr164Z133jFPIGzNz88PHh4eNk3BgCdzCMlksiznQSpbtiz+/vvvbB9PZpo1a4bPP/8cO3fuRP369Z3ernjx4gCAo0ePWtyb1q9f73AbuVyOGjVqoGzZsliyZAn++OOPTAOlxo0bIzg4GPPmzUOxYsXg4eGBjh07mtd7enqiXr16OHz4MCIiIjKdE83kn3/+gUwmc+olFhFZYqBERGY3btxA27Zt0bt3b9y7dw8jRoyAh4cHhgwZYk7z3XffoVmzZmjSpAm6d++O4OBg3LlzBydOnMAff/yBlStXAvj3DfX333+PfPnywcPDAyVKlDC/zW/QoAGmT58OjUaDOnXqAHjyJrREiRLYtm2bzUP522+/jSVLlqB58+b48MMPUb16dSiVSly6dAk///wzWrdujbZt26J48eIYPXo0hg0bhn/++QdNmzaFn58frl+/jt9//x1eXl52R4bKLq1Wax5yfNq0adDr9RYPhIULF0ZYWBiAJ01qPvvsMwwfPhwFChRA48aNceDAAYwcORK9evWyGNHrgw8+wJw5c9CzZ09UqlTJYp9qtdr88Fy2bFmULVvWIk+m4YnDwsLMwYBJUlKSeRh1g8GA8+fPY9WqVQCAmJgYFC5cGMCTZpWLFi1CixYtMHr0aKjVakycOBFpaWnmoYwB4NSpU+Yav3HjxuH06dM4ffq0eX1YWBgKFy4MDw8Pm7wATx605XK53XVP8/HxQXR0NCZPnoxChQqhePHiSEpKwpw5c+Dr65vpto6UK1cO77zzDqZNmwalUomGDRvi+PHjmDJlisNhtp/m7LEDTx7KGzVqhL59++L+/fsoVaoUli1bhi1btmDx4sXmgCQ711PNmjVt8mQq+ypVqtgME28qZ1NfmYMHD8Lb2xsA8MYbb5jTTZo0CY0aNcKbb76Jfv364caNG/j0009RsWJFi4B95cqVePfddxEVFYX33nvPZlj1ypUrQ61WQ61Wo1+/fpg6dSq6du2Kt956C3K5HGvXrsXSpUvx7rvvOmzSZxIbG4vRo0fj8ePH8PT0zDStswYMGIAVK1agdevW+PTTT1G9enVotVokJSUhLi4O9erVs7td8+bNUaBAAbz77rsYPXo0FAoF5s+fbzMk+qxZs7Bz5060aNECxYoVQ1paGubOnQsAWfaLksvl6Nq1q/llUbt27WxqKr/++mu8/vrrqFu3Lvr27YvixYvjwYMHOHPmDNavX28eKdFk//79iIqKchjME1EmXDeOBBHlFaZR7xYtWiQ++OADUbhwYaFWq0XdunXFwYMHbdIfOXJEdOjQQfj7+wulUimKFCki6tevL2bNmmWRbtq0aaJEiRJCLpfbjLa1bt06AUA0atTIYpvevXsLAOK///2vzefqdDoxZcoUERkZKTw8PIS3t7coW7aseO+998Tp06ct0q5du1bUq1dP+Pj4CLVaLUJDQ8Ubb7whtm/fbk7jaOQ1R6NbPc00wpyjP3sjp3399dciPDxcqFQqUaxYMTFixAibiUtDQ0Md7jM0NNSpPNkb9c40Ipi9P+uRCc+cOSPatGkjfHx8hKenp2jQoIE4dOiQRRrTSF+O/hxNamqSnVHvLl26JNq3by/8/PxEvnz5RNOmTcXx48dtJod1NPKb6fp++jjT09PFoEGDhL+/v/Dw8BA1a9YU+/btc2rC2ewe+4MHD8QHH3wgihQpIlQqlYiIiBDLli2zSPMs15O9PNkb9S6z/Vrbtm2bqFmzpvDw8BAFChQQXbt2tZlg1jRapKO/p0eiMxgM4ocffhBVq1YVvr6+wsfHR1SuXFl88803difttXbmzBkhSZLNyJSORr2rUKGCzT66detm8925e/eu+PDDD0WxYsWEUqkU/v7+okWLFuLkyZMW5816wtnff/9d1K5dW3h5eYng4GAxYsQIMXv2bIu87Nu3T7Rt21aEhoYKtVotChYsKGJiYkRCQoLFvuztXwghUlJSzOfS0ch8Z8+eFT179hTBwcFCqVSKwoULi9q1a4uxY8dapHvw4IHw9PQUX375pd39EFHmJCE4sD4RERHlTaaRLjdv3uzqrLx05syZgw8//BAXL15kjRLRM2CgRERERHnW8ePHUblyZezdu9eibxBlTq/Xo3z58ujWrRuGDRvm6uwQvZQ4PDgRERHlWRUrVsS8efPsjspJjl28eBHvvPMOBg0a5OqsEL20WKNERERERERkhTVKREREREREVhgoERERERERWWGgREREREREZMXtJ5w1Go24cuUK8uXLZ3fmcCIiIiIiejUIIfDgwQMEBQVBJsu8zsjtA6UrV64gJCTE1dkgIiIiIqI84uLFiyhatGimadw+UMqXLx+AJyfDx8fnmfah0+mwbds2NG7cGEqlMiezRy8Qy9F9sCzdA8vRfbAs3QPL0X2wLB27f/8+QkJCzDFCZtw+UDI1t/Px8XmuQMnT0xM+Pj682F5iLEf3wbJ0DyxH98GydA8sR/fBssyaM11yOJgDERERERGRFQZKREREREREVhgoERERERERWWGgREREREREZIWBEhERERERkRUGSkRERERERFYYKBEREREREVlhoERERERERGSFgRIREREREZEVBkpERERERERWGCgRERERERFZYaBERERERERkhYESERERERGRFQZKREREREREVhgoERERERERWWGgREREREREZIWBEhERERERkRUGSkRERERERFYYKBEREREREVlhoERERERERGSFgRIREREREZEVBkpERERERERWGCgRERERERFZYaBERERERERkhYESERERERGRFYWrM0BERERERO5Hq9NDLklQyGXQG4wwCAGN8uUJP/JMjdKECRMgSRIGDBhgXiaEwMiRIxEUFASNRoPY2Fj8+eefrsskERERERFlSpuhx4M0Hc7eegitzgAhAK3OgLO3HuJBmg7aDL2rs+iUPBHSHThwAN9//z0iIiIsln/xxReYOnUq5s+fj/DwcIwdOxaNGjXCqVOnkC9fPhflloiIiIiI7MnQG3AvTQcAWJV8EWuOXESqNgO+GhXaRoagT51SAAC5TIJKIXdlVrPk8hqlhw8fonPnzvjhhx/g5+dnXi6EwLRp0zBs2DC0a9cOFStWxIIFC/D48WMsXbrUhTkmIiIiIiJraRl6pOmNWPDbPyg2fC1GbDyK5Et3ce72IyRfuosRG4+i2PC1WPDbP0jXG5GWx2uWXB4oxcfHo0WLFmjYsKHF8rNnz+LatWto3LixeZlarUZMTAz27t37orNJRERERERP0er0yNAbYBQCOoMBBiHw7Z4UfLouGXqjEU3KBWLdezG4+8Wb0P+3I+5+8SZW9aqLn1Ou49s9p2EQrj6CzLm06d3y5cvxxx9/4MCBAzbrrl27BgAICAiwWB4QEIDz58873Gd6ejrS09PN/75//z4AQKfTQafTPVM+Tds96/aUN7Ac3QfL0j2wHN0Hy9I9sBzdR26XZVqGHmkGI3749QwSjl1CqlaHZd1ro4iPJ8ZvPopKRbyxpPvr8PNUYf7+fzB+8xGkanXw1SgRV7EoZneshruPM/AoLR0w6l9oE7zsnBNJCOGSWO7ixYuoWrUqtm3bhsjISABAbGwsoqKiMG3aNOzduxd16tTBlStXEBgYaN6ud+/euHjxIrZs2WJ3vyNHjsSoUaNsli9duhSenp65czBERERERJTnPX78GJ06dcK9e/fg4+OTaVqXBUpr165F27ZtIZf/G0EaDAZIkgSZTIZTp06hVKlS+OOPP1C5cmVzmtatW8PX1xcLFiywu197NUohISG4detWlifDEZ1Oh8TERDRq1AhKpfKZ9kGux3J0HyxL98BydB8sS/fAcnQfuVWWaRl6/LDvDD5bf9Rm3c2J7dFg+g780Kkmtvx1BSM22qaxNqZFBHrXKQWN6sU1crt//z4KFSrkVKDksqZ3DRo0wLFjxyyW9ejRA2XLlsUnn3yCkiVLokiRIkhMTDQHShkZGUhKSsKkSZMc7letVkOtVtssVyqVz32h5MQ+yPVYju6DZekeWI7ug2XpHliO7iOny/KhzohP1x+HzmC7TuOhRplAPxTK54lhG+2nsTZk43H0fL3MC73esvNZLguU8uXLh4oVK1os8/LyQsGCBc3LBwwYgPHjx6N06dIoXbo0xo8fD09PT3Tq1MkVWSYiIiIieiVpdXrM2J0CncFod32azoDuNUrih71nHKaxpjMYMXN3CgY2KJsnJ6LNezl6yscffwytVot+/frh7t27qFGjBrZt28Y5lIiIiIiIXiC5JGF18kWH6w9fvIvqoYUw8Kc/srXf1ckX8FHDcs+bvVyRpwKlXbt2WfxbkiSMHDkSI0eOdEl+iIiIiIgIUMhlSNVmOFw/dusxbOxbL9M09qRqdVDKXT5jkV15M1dERERERJRn6A1G+GpUDtdvPXEVGfrM09jjq1E63VTvRWOgREREREREmTIIgfZRIQ7XCwH88veNTNPY0z6qGIyuGYQ7SwyUiIiIiIgoUxqlAvHR4Zk2k5uy4wR61S7ldFM6pVyGftHheXIgB4CBEhEREREROcFDIcf4VpEO1287eRV3HmVgTFyEU/ub2DoKHoq8G47k3ZwREREREVGeoVEp0D+mDKa0fc1urZEQwJtz9qBf3XCHaYAnNUlT2r6G+OjwFzrZbHbl3ZwREREREVGeolbI0a9uafSsFYaZu1OwOvkCUrU6+GqUaB9VDP2iw6GUSVmm8VDIoFbIXX04mWKgRERERERETtOoFNCogIENyuKjhuWglMugMxhhFMKiv5EzafKylyOXRERERESUpzwd8DiqHXImTV7FPkpERERERERWGCgRERERERFZYaBERERERERkhYESERERERGRFQZKREREREREVhgoERERERERWWGgREREREREZIWBEhERERERkRUGSkRERERERFYYKBEREREREVlhoERERERERGSFgRIREREREZEVBkpERERERERWGCgRERERERFZYaBERERERERkhYESERERERGRFQZKREREREREVhgoERERERERWWGgREREREREZIWBEhERERERkRUGSkRERERERFYYKBEREREREVlhoERERERERGSFgRIREREREZEVBkpERERERERWGCgRERERERFZYaBERERERERkhYESERERERGRFQZKREREREREVhgoERERERERWWGgREREREREZIWBEhERERERkRUGSkRERERERFYYKBEREREREVlhoERERERERGSFgRIREREREZEVBkpERERERERWGCgRERERERFZYaBERERERERkhYESERERERGRFQZKREREREREVhgoERERERERWWGgREREREREZIWBEhERERERkRUGSkRERERERFYYKBEREREREVlhoERERERERGSFgRIREREREZEVBkpERERERERWGCgRERERERFZYaBERERERERkhYESERERERGRFQZKREREREREVhgoERERERERWWGgREREREREZIWBEhERERERkRUGSkRERERERFYYKBEREREREVlhoERERERERGSFgRIREREREZEVBkpERERERERWGCgRERERERFZYaBERERERERkhYESERERERGRFQZKr6iH6Tqk6w0wCoF0vQEP03WuzhIRERERUZ6hcHUG6MV6nKFHut6Ib5JO4acjF5GqzYCvRoV2kSF4P6YM1AoZPFW8LIiIiIjo1cYn4ldIms6AGbtTMGz9EegMxqfWPELypbsYs+U4xrWMxAcxZaBWyl2WTyIiIiIiV2Og9Ip4nKHHjN0p+HjtYYdpdAYjPl57GBKAftHhrFkiIiIiolcW+yi9ItJ0Bgxbf8SptEPXH0G63ph1QiIiIiIiN+XSQOnbb79FREQEfHx84OPjg1q1amHz5s3m9d27d4ckSRZ/NWvWdGGOX04P03WYsTvFqrmdYzqDETN2n+IAD0RElGdpdXpk/G9Qogy9AVqd3tVZIiI349K2VUWLFsXEiRNRqlQpAMCCBQvQunVrHD58GBUqVAAANG3aFPPmzTNvo1KpXJLXl5lSLsNPRy5ma5ufki9icMPyuZQjIiKiZ6PN0CNN/+SF3urkfwclah8VgvjoMvBQyKBh03EiygEuvZO0bNnS4t/jxo3Dt99+i/3795sDJbVajSJFirgie25DKZchVZuRrW1StTooZWyZSUREeUe63oAZe1IwNMH+oESjNx/H+FaR6B9TBmoFByUioueTZ165GAwGrFy5Eo8ePUKtWrXMy3ft2gV/f3/4+voiJiYG48aNg7+/v8P9pKenIz093fzv+/fvAwB0Oh10umdrSmba7lm3d7UMvQEBXkpcT3V+G38vBbTp6VC50Q/Ny16O9C+WpXtgObqPF1GWaRl6/LDvDD5ffxQKAPZ/noz4POEwZMKI3rXC4MGapWzhd9J9sCwdy845kYQQIhfzkqVjx46hVq1aSEtLg7e3N5YuXYrmzZsDAFasWAFvb2+Ehobi7NmzGD58OPR6PQ4dOgS1Wm13fyNHjsSoUaNsli9duhSenp65eixERERERJR3PX78GJ06dcK9e/fg4+OTaVqXB0oZGRm4cOECUlNTsXr1asyePRtJSUkoX962f8zVq1cRGhqK5cuXo127dnb3Z69GKSQkBLdu3cryZDii0+mQmJiIRo0aQalUPtM+XElnMOBhugGlRyU4NaCDUi7DmZGt4KWSQyl3rxqll7kc6V8sS/fAcnQfuV2WaTo9pielYOyW405vM7xpJbwfUxoeStYqOYvfSffBsnTs/v37KFSokFOBksvvHiqVyjyYQ9WqVXHgwAF8/fXX+O6772zSBgYGIjQ0FKdPn3a4P7Vabbe2SalUPveFkhP7cAmZDN4yBT5rHpnpPEomo1tGwstDDaVccqtAyeSlLUeywbJ0DyxH95FbZSkkGVYeuQytwfltVh65hIGNKkDpRk3IXxR+J90Hy9JWds5HnuutL4SwqBF62u3bt3Hx4kUEBga+4Fy93IR4EhH3jymDyW0qQym3X+xKuQyT21TG+zFloPjfdkRERK6meNZBiRz83hEROcOlNUpDhw5Fs2bNEBISggcPHmD58uXYtWsXtmzZgocPH2LkyJFo3749AgMDce7cOQwdOhSFChVC27ZtXZntl44QgIQnUXG/6HC8W7sUZuw+hZ+SLyJVq4OvRol2/xtWVa2QmaNnBkpERJQX6A1G+GpUAB45vY2vRgmdwcjR74jombk0ULp+/Tq6dOmCq1evIn/+/IiIiMCWLVvQqFEjaLVaHDt2DAsXLkRqaioCAwNRr149rFixAvny5XNltl86EgDxv/8CgJdKjg9jy2Jww/JQymTQGY3I0BuhVsigNz6Jjp5OT0RE5EoGIdA+KgTJl+46vU37qGIw8o0fET0HlwZKc+bMcbhOo9Fg69atLzA37ssongQ+cjz5b2ZM640AJP6+EBFRHqBRKhAfHY7Rm487PShRv+hwaDiQAxE9BzbefQVIMkD8LwQSQsAoBKwHO7ReLiAg8eogIqI8wkMhx/hWkU6lndg6Ch4K/ogR0fPhXeQVYGqfrRNGQABGIZBhMP5bfSSADIPxSRMF8b90kNium4iI8gyNSoH+MWUwpe1rmQ5KNKXta4iPDoeGk80S0XPiXeQVIYMEvRB4mK6Hl1pu0wRPADAYBR6lG+DtoYCcHZSIiCiPUSvk6Fe3NHrWCsPM3SlYnXzBPChR+6hi6BcdDg+FjC/6iChHMFB6RXioFMjQGwAJ0BkEbjxIg0oug1wmIU1vwI0HaQj00QASoJLLoOKPDBER5THaDD3S9EZs/usyapcshPjocHirFUjTG2AUgFoug1rJ3y8iyhkMlF4hKoUc+T2U0BsFJKsx7SRIUMpl0CjlDJKIiCjPSdcbMGNPCoYmHLE7oINSLsP4VpHoH1OGNUpElCMYKL1iTG22SxTygkySIJNJ8FDKUaKQF0cHIiKiPEmboceMPSkYvOawwzQ6gxGD1xyGBAn96pZmHyUiem4czOEVpVEqoFbIIZOeDNrAIImIiPKqNL0BQxOOOJV2SEIy0vRZDyFORJQVBkpERESUZ2l1eszYneLU/EnAk5qlmbtToNXpczlnROTuGCgRERFRniWXJKxOvpitbVYnX4BM4vCtRPR8GCgRERFRnqWQy5CqzcjWNqlancO5loiInMW7CBEREeVZeoMRvhpVtrbx1SidbqpHROQIAyUiIiLKswxCoH1USLa2aR9VDEZhPbU6EVH2MFAiIiKiPEujVCA+OtzppnRKuQz9osM5misRPTcGSkRERJSneSjkGN8q0qm0E1tHwUPBxxsien583UJERER5mkalQP+YMpAgYUhCst3+R0q5DBNaRSE+OhxqhdwFuSQid8NAiYiIiPI8tUKOfnVLo2etMMzcnYLVyReQqtXBV6NE+6hi6BcdDg+FjEESEeUYBkpERET0UtCoFNCogIENyuKjhuWglMugMxhhFIJ9kogox/GuQkRERC+Vp4Mi1iARUW5hb0ciIiIiIiIrDJSIiIiIiIisMFAiIiIiIiKywkCJiIiIiIjICgMlIiIiIiIiKwyUiIiIiIiIrDBQIiIiIiIissJAiYiIiIiIyAoDJSIiIiIiIisMlIiIiIiIiKwwUCIiIiIiIrLCQImIiIiIiMgKAyUiIiIiIiIrDJSIiIiIiIisMFAiIiIiIiKywkCJiIiIiIjICgMlIiIiIiIiKwyUiIiIiIiIrDBQIiIiIiIissJAiYiIiIiIyAoDJSIiIiIiIisMlIiIiIiIiKwwUCIiIiIiIrLCQImIiIiIiMgKAyUiIiIiIiIrDJSIiIiIiIisMFAiIiIiIiKywkCJiIiIiIjICgMlIiIiIiIiKwyUiIiIiIiIrDBQIiIiIiIissJAiYiIiIiIyAoDJSIiIiIiIisMlIiIiIiIiKwwUCIiIiIiIrLCQImIiIiIiMgKAyUiIiIiIiIrDJSIiIiIiIisMFAiIiIiIiKywkCJiIiIiIjICgMlIiIiIiIiKwyUiIiIiIiIrChcnQF6cbQ6PeSSBIVcBr3BCIMQ0Ch5CRARERERWeNT8itAm6FHmt6IGbtPYXXyRaRqM+CrUaF9VAjio8vAQyGDRsVLgYiIiIjIhE/Hbi5db8CMPSkYmnAEOoPxqTWPkHzpLkZvPo7xrSLRP6YM1Aq5y/JJRERERJSXMFByY9oMPWbsScHgNYcdptEZjBi85jAkSOhXtzRrloiIiIiIwMEc3Fqa3oChCUecSjskIRlpemPWCYmIiIiIXgEMlNyUVqfHjN0pVs3tHNMZjJi5OwVanT6Xc0ZERERElPcxUHJTcknC6uSL2dpmdfIFyCQpl3JERERERPTyYKDkphRyGVK1GdnaJlWrg1LOS4KIiIiIiE/FbkpvMMJXo8rWNr4apdNN9YiIiIiI3BkDJTelMxjRLjIkW9u0iwqBnoESEREREREDJXelUsjQu04pp5vSKeX/S6/gJUFERERExKdiNyWXyXA/TYcxcRFOpR8bF4l7Wh0UMl4SRERERER8KnZT+v9NJNuzZhgmta7ssGZJKZdhUuvK6FGzJD5ec5h9lIiIiIiIAChcnQHKHTqDEVWLFUCdr7Zhbe8YdK1RAj/8egZrjlxEqlYHX40SbSND0LtOKdx5lIE6X21D1+oloDcYoVbIXZ19IiIiIiKXYqDkpkx9lMZsOY6K4zegUdlAxEeH4/2YcORTK/EgXYc9f99Et0X7kHjyKhQy9lEiIiIiIjJhoOSmnu6j9Om6ZGw7cRXbTlx1mN7UR6mwt8cLzCURERERUd7E6gM3xT5KRERERETPzqWB0rfffouIiAj4+PjAx8cHtWrVwubNm83rhRAYOXIkgoKCoNFoEBsbiz///NOFOX55GIRAtdAnfZTiKgbjwpg2GN0iApWL+qFEQW9ULuqH0S0icGFMG8RVDEadr7ahWmhBGIVwddaJiIiIiFzOpU3vihYtiokTJ6JUqVIAgAULFqB169Y4fPgwKlSogC+++AJTp07F/PnzER4ejrFjx6JRo0Y4deoU8uXL58qs53kapQL9osMxerPzfZT6RYdDo2RrTCIiIiIilz4Vt2zZ0uLf48aNw7fffov9+/ejfPnymDZtGoYNG4Z27doBeBJIBQQEYOnSpXjvvfdckeWXhjZDjwy90ek+ShNbRcGDAzkQEREREQHIQ4M5GAwGrFy5Eo8ePUKtWrVw9uxZXLt2DY0bNzanUavViImJwd69ex0GSunp6UhPTzf/+/79+wAAnU4HnU73THkzbfes27vCw7QMNP9mJzb2rQe5MGLMluN2+x8p5TIMb1oRfWqVgEISL9UxZtfLWI5kH8vSPbAc3QfL0j2wHN0Hy9Kx7JwTSQjXdko5duwYatWqhbS0NHh7e2Pp0qVo3rw59u7dizp16uDy5csICgoyp+/Tpw/Onz+PrVu32t3fyJEjMWrUKJvlS5cuhaenZ64dBxERERER5W2PHz9Gp06dcO/ePfj4+GSa1uU1SmXKlEFycjJSU1OxevVqdOvWDUlJSeb1kiRZpBdC2Cx72pAhQzBw4EDzv+/fv4+QkBA0btw4y5PhiE6nQ2JiIho1agSlUvlM+3iRMvQGNJi+A0cvpwIAJAmoF14EveuUQu0SheCtUuBhhh57z97CD7+ewc8p11ApyBc7+jeAyo0nm33ZypEcY1m6B5aj+2BZugeWo/tgWTpmam3mDJcHSiqVyjyYQ9WqVXHgwAF8/fXX+OSTTwAA165dQ2BgoDn9jRs3EBAQ4HB/arUaarXaZrlSqXzuCyUn9vEiyBUKXH+kg9bw77KNf13Dxr+uOdzmxiM9NB5qyDIJQt3Fy1KOlDWWpXtgOboPlqV7YDm6D5alreycjzzXe18IgfT0dJQoUQJFihRBYmKieV1GRgaSkpJQu3ZtF+Yw79MbjPDVqLK1ja9GyTmUiIiIiIj+x6U1SkOHDkWzZs0QEhKCBw8eYPny5di1axe2bNkCSZIwYMAAjB8/HqVLl0bp0qUxfvx4eHp6olOnTq7Mdp6nMxjRLjIEyZfuOr1Nu6gQ6A1GqN246R0RERERkbNcGihdv34dXbp0wdWrV5E/f35ERERgy5YtaNSoEQDg448/hlarRb9+/XD37l3UqFED27Zt4xxKWVApZOhdp5TDke6sKeVP0is5PDgREREREQAXB0pz5szJdL0kSRg5ciRGjhz5YjLkJuQyGe6n6cxzKGVlbFwk7ml1KOztkfuZIyIiIiJ6CbAKwQ3pDUYMXnMYPWuGYVLrylDK7RezUi7DpNaV0aNmSXy85jD7KBERERER/Y/LR72jnKczGFG1WAHU+Wob1vaOQdcaJfDDr2ew5shFpGp18NUo0TYyBL3rlMKdRxmo89U2dK1egn2UiIiIiIj+h4GSG3q6j1LF8RvQqGwg4qPD8X5MOPKplXiQrsOev2+i26J9SDx5FQoZ+ygRERERET2NgZIbsu6jtO3EVWw7cdVhevZRIiIiIiKyxCoEN8Q+SkREREREz4c1Sm7IIASqhWavj1K36iVhFMLVWSciIiIiyhMYKLkhjVKB+OhwjN7sfB+lftHh0Ch5ORARERERAQyU3JaHQo7xrSIxeM3hLPsoTWwdBQ8O5EBEREREZMZAyU1pVAq8H10GEiQMSUi22/9IKZdhQqsoxEeHc1hwIiIiIqKnMFByU+l6A5YcOItmFYLQuVpxu32U+tYtDU+VgkESEREREZEVBkpuSJuhx4w9KRi85jAkCQ77KHVesBeNywaiX93S0Kh4KRARERERmfDp2A2l6Q0YmnAEACAEMu2j9HPKdfSsFQaN6kXmkIiIiIgob2MPfjej1ekxY3eK03Mi6QxGzNydAq1On8s5IyIiIiJ6eTBQcjNyScLq5IvZ2mZ18gXIJCmXckRERERE9PJhoORmFHIZUrUZ2domVauDUs5LgYiIiIjIhE/HbkZvMMLXUYej+zeBLV//++/zR4DfV8NXo0RsbCyio6PRoEEDtGzZEsePH3fq8xYsWIC6deuiZs2aGDx4MADg0KFDqFu3LmJiYtChQwfodDoAQHR0NGJjY1G7dm2L/RuNRpQvXx7ffPPNsx00EREREVEOY6DkZnQGI9pFhmRrm3ZRIRAC2LRpE3bs2IFx48ahQ4cOSEtLy3LbTp06Yc+ePdi/fz8OHTqEixcvIjg4GFu3bkVSUhJKlSqFtWvXAgB27NiBXbt2YcKECfjqq6/M+1i2bBmKFSuWrTwTEREREeUmBkpuRqWQoXedUk43pZNJEnrXKQXZU12UIiIiULVqVRw4cCDL7ZVKJQBAr9cjf/78KFiwIIoUKQJPT0/zeoVCYZH2/v37qFSpEgDAYDBg5cqV6NChg9PHSERERESU2xgouRm5TIb7aTqMiYuwn+DySWDN2Cd/+5ajfngR3NPqIFkN5hAUFIQrV6449ZmTJ09GeHg4ChYsaA6QAODChQvYvn074uLiAAA3b95EnTp10K9fP0RHRwMAlixZgjfffBMyGS9FIiIiIso7+HTqZvQGIwavOYyeNcMwqXVl25ql4LJA28+gfONz9Bw4DFFF/fDxmsMwCmGR7MqVKwgKCnLqMwcPHozTp0/jxo0b2L9/P4AntUZdunTBvHnzzDVJhQsXxq+//orVq1dj6NChMBgMWLFiBd5+++3nP3AiIiIiohzEQMnN6AxGVC1WAHW+2oa4isG4MKYNRreIQOWifijq5wlfjQqjW0Tgwpg2qF68EObu/xtVQwvg6Tjp+PHjOHToEKpVq5bl56WnpwMA5HI5vLy84OnpCYPBgM6dO+Pzzz9HeHg4gCdN84zGJ3M75c+fH15eXrh27RquX7+OFi1a4Msvv8TMmTNx6NChnD8pRERERETZpHB1BihnmfoojdlyHBXHb0CjsoGIjw7H+zHhuH31MgZe2ILIon7otmgftm39DbLHGehdpxQSJaB58+ZQKpXw9PTEihUr4OHhkeXnffHFF9ixYwf0ej0aNmyIiIgILFu2DHv37sWDBw8wZswY9O3bF6+//jo6deoEmUwGmUyGGTNmIDg4GAcPHgQAzJ8/Hw8fPkSVKlVy+xQREREREWWJgZKbebqP0qfrkrHtxFVsO3H13wTB7bH+u6Qn/18sEhP6d8c9rQ4/79r1TJPODh8+HMOHD7dY1rFjR3Ts2NEmbVJSksP9dO/ePdufTURERESUW9j0zs1k2Ufpf5RyGSa1roweNUvi4zWHoTMYX3BOiYiIiIjyLtYouRmDEKgW+qSP0treMehaowR++PUM1hy5iFStDr4aJdpGhqB3nVK48ygDdb7ahm7VS9oM5kBERERE9CpjoORmNEoF4qPDMXqzbR+lfGolHqTrsOfvm+i2aB8ST16FQiZDv+hwaJS8FIiIiIiITPh0nMdodXrIJQkKuQx6gxEGIbIdxHgo5BjfKhKD1xy27aNkZWLrKHgo2AKTiIiIiOhpDJTyCG2GHml6I2bsPoXVyReRqs2Ar0aF9lEhiI8uAw+FDBqVc8WlUSnQP6YMJEgYkpBst/+RUi7DhFZRiI8Oh1ohz+nDISIiIiJ6qTFQygPS9QbM2JOCoQlHrIKaR0i+dBejNx/H+FaR6B9TxumgRq2Qo1/d0uhZKwwzd6dgdfIFcx+l9lHF0C86HB4KGYMkIiIiIiI7GCi5mDZDjxl7UjB4zWGHaXT/G8lOgoR+dUtnq2ZJowIGNiiLjxqWg1Iug85ghPEZmvMREREREb1K2DnFxdL0BgxNOOJU2iEJyUjTZ38Yb41SAbVCDpkkQa2QM0giIiIiIsoCAyUX0ur0mLE7xek5jHQGI2buToFWp8/lnBERERERvdoYKLmQXJKwOvlitrZZnXwBMknKpRwRERERERHAPkoupZDLkKrNyNY2qVodlHLGt0RE5P5yYsoMIqJnxbuNC+kMRvhqVAAeOb2Nr0YJncHI0eqIiMht5eSUGUREz4p3GRfR6vQ4e+sh2kaGIPnSXae3ax9VDEYhcjFnRERErpMbU2YQET0LtuFyEbkkYcbuFPSuXcrppnRKuQz9osPZ7ICIiNySNkOP6UmnMHjNYYcDHZmmzPgmKQXaDA5uRES5h4GSiyjkMmw+cQV3H2dgTFyEU9uMi4uEh4JFRkRE7ulFTJlBROQsPnW7iN5gRH4PFdr8kISeNcMwqXVlhzVLSrkMk1pXRs/aYZDLOOIdERG5H06ZQUR5DQMlF9EZjGgXGYLTNx6gzlfbEFcxGBfGtMHoFhGoXNQPJQp6o3JRP4xuEYELY9ogrmIwVhw65/QPCBER0cuEU2YQUV7Dzi4uolLI0LtOKYzZchynbzxAxfEb0KhsIOKjw/F+TDjyqZV4kK7Dnr9votuifdh1+joujGkDJZveERGRG3rmKTNk/F0kotzBQMlF5DIZ7qfpMCYuAp+uS4YQwLYTV7HtxFW76Se1rox7Wh0Ke3u84JwSERHlvmeeMsNohFrG0e+IKOfxNYyL6P83ao+z/ZN61CyJjzMZBYiIiOhlZjQKtI0MydY2bSNDYDRyygwiyh0MlFzEIASqhRZwun9Sna+2oVpoQc6hREREbkkul9CnTvamzOjzeinI5eyjRES5g03vXESjVCA+OhyjNx/Psn9S4smrUMg4hxIREbkvnV7AKGBukp6VsXGRMBqfbKdiyzsiygV86nYhD4Uc41tFYvCaw5n2TwKAia2jOIcSERG5LYVMgodchp61wiBBwmcbjthtbq6UyzA2LhI9apWEXJKg4LQZRJRLGCi5kEalQP/oMoAAhq53/IMwvmUk4uuGQ63kKzMiInJPkgxQKWVYevAc4ioGo2uNEvjh1zNYc+QiUrU6+GqUaBsZgt51SuHOowysPXIJHauGQuI7RCLKJQyUXEibocfSg+fQvEIw3qme+Q/CkgPn0LFqKDQqFhkREbkfg0HgUYYBb1cpjll7TiPpzHW893ppmybp7y7Zj5hSAfhP3dJ4nGGAXJIAvkckolzAp24XStMb0HfFAeiNRqf6KLWNCoFG5epcExER5SytTg+5XIJMejIqbNfqJcw1SiM3HrV4gTinc01APEknk8DBHIgo1zBQchGtTo8Zu1PMze2y6qOkMxgxc3cKBjYoywEdiIjIrcgkCek6I3QGgTXHL+L1kv4o4uOBdlEh+CC2DLxUCjzK0ONS6mOo5DJcu5+GX/+5ibiKwRzMgYhyDVv2uohckrA6+WK2tlmdfAEyiW/OiIjIvSjlMpy+8QAechnaRoZgw/HL6LJwL/6+9dA8LYZRCPx96yG6LNyLDccvo01kUagVMihYo0REuYRVEy6ikMuQqs3I1japWp3T80sQERG9LHQGI+buO4OJrStj6SHLwRzsNb0zDebQqWpxqBWsTiKi3MFAyUX0BiN8NSoAj5zexlejhM5g5I8CERG5Fb1BwN9Hg2v307I1mANHBiei3MRAyUV0BiPaRYYg+dJdp7dpFxUCPQMlIiJyMwqZhL6vl0bs19uxZ0AjpwZzUMtlYJxERLmJgZKLqBQy9K5TCmO2HLc7f5I1pfxJeiUnnSUiIjcjyQCNSo6uNUqg5tStWNs7JtPBHDL0RuiFkc3RiShX8Q7jInKZDPfTdBgTF+FU+rFxkbin1UEhY5EREZF7Mc2h1LduOHrVKoXKkzah4/xfbQZz+OfWQ2w/dQ2eagUepRtgMAgX55yI3BlrlFxEZzBi8JrDmN2pBiRI+GzDEbs1S0q5DGPjItGjZkn0XvobVrz7OpveERGRW3F2DqXedUpxDiUiemEYKLmAVqfH2VsPUaVYAdT5ahvW9o4x/yisOXLR5kfhzqMM1PlqG7pVL2l+s0ZEROQudHrBOZSIKM9hoOQCcknCjN0p+KxpJYzdchwVx29Ao7KBiI8Otxndp9uifUg8eRUKmQz9osM52SwREbkdhUwyz6E0b98/5hHvgvJrAPw7h9LHaw8jplQAetQqCbkkQcFh74goF/Gp2wUUchk2n7iC+OgyGBMXgU/XJWPbiavYduKqw23GxUXCgwM5EBGRG5JkgEopw9KDzs+h1LFqKCT+LBJRLmKg5AJ6gxH5PVRo80MSfv2/xk71UepZOwxyvjkjIiI3pNM/GcwhO3MoPc4wQILEpndElGsYKLmAQQi0jwrB8A1Hne6j9OOh8+heq6Srs05ERJTjFDIJSknKcjAH0xxKeoMRChmb3hFR7mKg5AIapQLx0eEYvfk4Tt94kGUfpV2nr+Pa+Pbsn0RERG7p6aZ3zg7mwKZ3RJTb+OTtIh4KOca3isTgNYchBDLto/Rlu9fYP4mIiNyWo6Z3jgZzYNM7InoRGCi5iEalQP+YMpAgYUhCssP+SRNaRSE+OpxzJxERkdti0zsiyosYKLmQWiFHv7ql0bNWGGbuTsHq5AvmH4T2UcXQLzocHgoZgyQiInJrbHpHRHkRAyUX06gU0KiAgQ3K4qOG5aCUy6AzGGEUgn2SiIjI7Wl1ehiNYNM7Ispz+CSeRzwdFLEGiYiIXhVySYIkA5veEVGew0CJiIiIXEYhl0GboWfTOyLKc3iLISIiIpfRGYz4/fxtc9O7Dccvo8vCvfj71kMYhQDwb9O7Lgv3YsPxy3irSigeZxhgMAoX556I3BlrlIiIiMhljEaBK/e0qBDom62md2qFjH15iShX8Q5DRERELqOQS2hQpghuPUrHL3/fcKrp3f6zt/B21VBXZ52I3Byb3hEREZHL6I0CQgC//H0DbSNCsmx6t+nPy+hYrTg4jgMR5TbWKBEREZHLaJQKZKiMaBsZgrVHLiGuUrDDpncLutSCh1IOvcGAfB4qV2ediNwcAyUiIiJyKZVchlWHL6BOycIo4KnCjlPX8HpYYfSPKQNvtQJp+icDN6Q+1iHh2GV0rMJmd0SU+9j0joiIiFxKo1LgneolsPmvK3h3yX7k81AiqqgfvNUKPEjXYWfKdXSa/ytWJV9A52rFoVHxPS8R5T7eaYiIiMjl1Ao5+tUtjZ61wjBzd4pFs7v2UcWwuFsdeChknJSdiF4Yl9YoTZgwAdWqVUO+fPng7++PNm3a4NSpUxZpunfvDkmSLP5q1qzpohwTERFRbtGoFPDzVGFgg7LY91ETnBnZCvs+aoKBDcrCz1PFmiQieqFcGiglJSUhPj4e+/fvR2JiIvR6PRo3boxHjx5ZpGvatCmuXr1q/tu0aZOLckxERES5TaNUQK2QQyZJUCvknC+JiFzCpXeeLVu2WPx73rx58Pf3x6FDhxAdHW1erlarUaRIkRedPSIiIiIiekXlqVc09+7dAwAUKFDAYvmuXbvg7+8PX19fxMTEYNy4cfD397e7j/T0dKSnp5v/ff/+fQCATqeDTqd7pnyZtnvW7SlvYDm6D5ale2A5ug+WpXtgOboPlqVj2TknkhD/m83NxYQQaN26Ne7evYs9e/aYl69YsQLe3t4IDQ3F2bNnMXz4cOj1ehw6dAhqtdpmPyNHjsSoUaNsli9duhSenp65egxERERERJR3PX78GJ06dcK9e/fg4+OTado8EyjFx8dj48aN+OWXX1C0aFGH6a5evYrQ0FAsX74c7dq1s1lvr0YpJCQEt27dyvJkOKLT6ZCYmIhGjRpBqVQ+0z7I9ViO7oNl6R5Yju6DZekeWI7ug2Xp2P3791GoUCGnAqU80fSuf//+SEhIwO7duzMNkgAgMDAQoaGhOH36tN31arXabk2TUql87gslJ/ZBrsdydB8sS/fAcnQfLEv3wHJ0HyxLW9k5Hy4NlIQQ6N+/P9asWYNdu3ahRIkSWW5z+/ZtXLx4EYGBgS8gh0RERERE9Cpy6fDg8fHxWLx4MZYuXYp8+fLh2rVruHbtGrRaLQDg4cOH+Oijj7Bv3z6cO3cOu3btQsuWLVGoUCG0bdvWlVknIiIiIiI35tIapW+//RYAEBsba7F83rx56N69O+RyOY4dO4aFCxciNTUVgYGBqFevHlasWIF8+fK5IMdERERERPQqcHnTu8xoNBps3br1BeWGiIiIiIjoCZc2vSMiIiIiIsqL8sSod686rU4PuSRBIZdBbzDCIAQ0ShYNEREREZGr8GnchbQZeqTpjZix+xRWJ19EqjYDvhoV2keFID66DDwUMmhULCIiIiIioheNT+Eukq43YMaeFAxNOAKdwfjUmkdIvnQXozcfx/hWkegfUwZqhdxl+SQiIiIiehUxUHIBbYYeM/akYPCaww7T6AxGDF5zGBIk9KtbmjVLREREREQvEAdzcIE0vQFDE444lXZIQjLS9MasExIRERERUY5hoPSCaXV6zNidYtXczjGdwYiZu1Og1elzOWdERERERGTCQOkFk0sSVidfzNY2q5MvQCZJuZQjIiIiIiKyxkDpBVPIZUjVZmRrm1StDko5i4qIiIiI6EXh0/cLpjcY4atRZWsbX43S6aZ6RERERET0/BgovWA6gxHtIkOytU27qBDoGSgR5QqtTo8MvQFGIZChN7A/IBEREQHg8OAvnEohQ+86pTBmy3GnaomU8ifplQrGtEQ5iRM+ExERUWb4FPCCyWUy3E/TYUxcBD5dl5xl+rFxkbin1aGwt0fuZ47oFcEJn4mIiCgrrKZ4wUwTyfasGYZJrSs7HKRBKZdhUuvK6FGzJD5ec5h9lIhyiDZDj+lJpzA4k++V6Xv6TVIKtBlsikdERPQqYo3SC6TV6XH21kNUKVYAdb7ahrW9Y9C1Rgn88OsZrDlyEalaHXw1SrSNDEHvOqVw51EG6ny1Dd2ql4RRCFdnn8gtZHfC5561wpDN8VeIiIjIDTBQeoHkkoQZu1PwWdNKGLvlOCqO34BGZQMRHx2O92PCkU+txIN0Hfb8fRPdFu1D4smrUMhk6BcdDo2SRUX0vJ51wueBDcryO0hERPSK4S//C6SQy7D5xBXER5cx91HaduIqtp246nCbcXGR8OBADkQ54lknfP6oYblcyhERERHlVXwCf4H0BiPye6jQ5ockp/so9awdBrlMesE5JXJPnPCZiIiInMVf/xfIIATaR4Xg9I0HqPPVNsRVDMaFMW0wukUEKhf1Q4mC3qhc1A+jW0Tgwpg2iKsYjB8PnYeB/ZOIcgQnfCYiIiJnsendC6RRKhAfHY7Rm4/j9I0HWfZR2nX6Oq6Nb8++EUQ5xPSyIvnSXae3aR9VjIOpEBERvYL4BP6CeSjkGN8qEoPXHIYQyLSP0pftXmP/JKIc9PTLCmcnfOZgKkRERK8mPoW/YBqVAv1jymBK29cy7Z80pe1riI8Oh0bFBzSinGR6WeGMia2j+LKCiIjoFcWncBdQK+ToV7c0etYKw8zdKVidfME8h1L7qGLoFx0OD4UMaoXc1VklcjumlxUSJAxJSLZbs6SUyzChVRTio8P5PSQiInpFMVByEY1KAY0KGNigLD5qWA5KuQw6gxFGIdjMhyiX8WUFERERZYVP5C72dFDEhzKiF4cvK4iIiCgzfBogolcaX1YQERGRPeylTEREREREZIWBEhERERERkRUGSkRERERERFYYKBEREREREVlhoERERERERGSFo94R0StLq9NDLklQyGXQG4wwcGhwIiIi+h8+ERDRK0eboUea3ogZu09hdfJFpGoz4KtRoX1UCOKjy8BDIYNGxdsjERHRq4xPAkT0SknXGzBjTwqGJhyBzmB8as0jJF+6i9Gbj2N8q0j0jynDeZWIiIheYQyUiOiVoc3QY8aeFAxec9hhGp3BiMFrDkOChH51S7NmiYiI6BXFwRyI6JWRpjdgaMIRp9IOSUhGmt6YdUIiIiJySwyUiOiVoNXpMWN3ilVzO8d0BiNm7k6BVqfP5ZwRERFRXvRcgVJaWlpO5YOIKFfJJQmrky9ma5vVyRcgk6RcyhERERHlZdkOlIxGI8aMGYPg4GB4e3vjn3/+AQAMHz4cc+bMyfEMEhHlBIVchlRtRra2SdXqoJSz4p2IiOhVlO0ngLFjx2L+/Pn44osvoFKpzMsrVaqE2bNn52jmiIhyit5ghK9GlXXCp/hqlE431SMiIiL3ku1AaeHChfj+++/RuXNnyOX/Dp0bERGBkydP5mjmiIhyikEItI8Ksb/y/k1gy9f//vv8EeD31WgfVQyNGtRHdHQ0GjRogJYtW+L48eM2m7///vt4/fXXUbNmTWzduhUAsHfvXlSsWBFFihQxpzt06BDq1q2LmJgYdOjQATqdDgBw6dIltGrVCrGxsRg1apTDfX7//feIjY1FbGwsAgICsG7dupw4NURERGRHtse9vXz5MkqVKmWz3Gg0mn/0iYjyGo1SgfjocIzefNypWiKZJKFfdDgSJ0rYsHEjvL29cfToUXTo0AF//PEHPDw8zGkHDhyIkiVL4u7du2jSpAmaNGmCChUq4Pfff0d0dLQ5XXBwMLZu3QpPT08MHToUa9euxZtvvonBgwfj22+/RXBwcKb77NOnD/r06QMAiIyMRKNGjXLwDBEREdHTsl2jVKFCBezZs8dm+cqVK1G5cuUcyRQRUW7wUMgxvlWkU2kbli0CD4XlLTIiIgJVq1bFgQMHLJaXLFkSAKBWqyGTPdkmf/788PT0tEhXpEgR8zKlUgmFQgGdTodz585h0KBBqF+/Pvbu3etwnyaHDx9GmTJlbPZPREREOSfbNUojRoxAly5dcPnyZRiNRvz00084deoUFi5ciA0bNuRGHomIcoQEoE+d0jAagc82HLGsWbp8ElgzFpIkIUBlwGudOsDeeHdBQUG4cuWK3f0PGzYMH3zwQZb5uHDhArZv347PPvsMt27dwtGjR7Fy5UooFAq0atUKv//+e6b7XLlyJd58801nDpmIiIieUbZrlFq2bIkVK1Zg06ZNkCQJn3/+OU6cOIH169ezGQgR5WlavQG1pmxFXMVgXBjTBqNbRKByUT8U9fOEb6kIjJ79I678dQgjx47H7L1/Q2tnwtkrV64gKCjIZvm8efOQkZGBTp06ZZqH+/fvo0uXLpg3bx6USiV8fX0RHh6OokWLokiRIlAoFNDr9Znuc9OmTWjevPlznAkiIiLKSrZrlACY28sTEb0sTBPO/nXtHiqO34BGZQMRHx2O92PCcfvqZQy8sAWRRf3QbdE+bNv6G/AwDTN3p8AohHkfx48fx6FDh/D9999b7Pvnn3/G6tWrsXbt2kzzYDAY0LlzZ3z++ecIDw8HAGg0Gvj6+uLevXtQKBTIyMiAQqFwuM/k5GSULl0aXl5eOXJeiIiIyL5nCpSIiF42T084KwSw7cRVbDtx9cnK+zeBY5ew/rukJ//+X2y0OvkCvAE0b94cSqUSnp6eWLFihcVADgDwn//8B97e3mjYsCE0Gg02b96MEydOoH///khJSUHDhg0xefJknDx5Env37sWDBw8wZswY9O3bF2+99RbGjRuHuLg46HQ6jBkzxuE+ATa7I/ek1ekhlyQo5DLoDUYYhIBGyUcUInItp+5Cfn5+kJycnf7OnTvPlSEiotyQ6YSzPoWBph/+++/QSCA0EqlaHQ7u2gVZFve/U6dO2SwrV64ctm/fbrGscuXK6Nixo03a2rVr2wySY2+fADBu3LhM80L0MtFm6JGmN2LG7lNYnXwRqdoM+GpUaB8VgvjoMvBQyKBRMWAiItdw6u4zbdq0XM4GEVHu+nfC2UdOb2OacFatkGedmIiyJV1vwIw9KRiaYDWwCh4h+dJdjN58HONbRaJ/TBl+B4nIJZwKlLp165bb+SAiylWmCWeTL911epv2UcUs+igRUc7QZugxY08KBq857DCNzmDE4DWHIUFCv7qlWbNERC9ctke9u3//vt2/Bw8eICPDQbMWskur0yNDb4BRCGToDdDq9K7OEpHbMk04q5Q7d9tTymXoFx3OfhJEuUCrN2BowhGn0g5JSEaanREoiYhyW7YDJV9fX/j5+dn8+fr6QqPRIDQ0FCNGjIDRyJuaI9oMPe4+zsCXO06gxpStCBu5DjWmbMWXO07g7uMMaDMYMBHlhuxMODuxdZTNhLNE9PwepeswIynFqrmdYzqDETN3p/BlIhG9cNl+VTp//nwMGzYM3bt3R/Xq1SGEwIEDB7BgwQJ89tlnuHnzJqZMmQK1Wo2hQ4fmRp5famyTTeQ6GpUC/WPKQIKEIQnJdh/UlHIZJrSKQnx0OL+DRLlAIZfhpyMXs7XN6uQL+KhhuVzKERGRfdkOlBYsWIAvv/wSHTp0MC9r1aoVKlWqhO+++w47duxAsWLFMG7cOAZKVtgmm8j11Ao5+tUtjZ61wjBzdwpWJ19AqlYHX40S7aOKoV90ODwUMgZJRLlAq9NDJZc7HoHSgVStzulms0REOSXbT+H79u3DrFmzbJZXrlwZ+/btAwC8/vrruHDhwvPnzs2kZbNNds9aYdCocjlTRK8gjUoBjQoY2KAsPmpYDkq5DDqDEUbO3UKUq+SShIfpOo5ASUQvhWy/nilatCjmzJljs3zOnDkICQkBANy+fRt+fn7Pnzs3otXpMWM322QT5SUapQJqhRwySYJaIWeQRJTLFHIZfj93G20jQ7K1HUegJCJXyPZTwZQpU/Dmm29i8+bNqFatGiRJwoEDB3Dy5EmsWrUKAHDgwAG89dZbOZ7Zl5lckrA6mW2yiYjo1aU3GLH26EV81rQSxm457tTLQ45ASUSuku27TqtWrXDq1CnMmjULKSkpEEKgWbNmWLt2LYoXLw4A6Nu3b07n86WnkMvYJpuIiF5pBiEQmF+Du48zMCYuAp+uS85ym/EtI6HmCJRE5ALP9HqmePHimDhxYk7nxa3pDUa2ySYioleaaT6z16cmYteHDSFBwmcbrEeBfUIpl2FsXCTejykDDyV/B4noxXumQCk1NRW///47bty4YTNfUteuXXMkY+7GIATaR4Ug+dJdp7dhm2wiInI3Hgo5etQqiTpfbcPa3jHoWqMEfvj1DNYcuWgegbJtZAh61yn1ZAP+DhKRi2Q7UFq/fj06d+6MR48eIV++fJAkybxOkiQGSg6Y3qKN3sw22URE9Op6ej6zypM2IbZ0AOKjw/F+TDjyqZV4kK7DL3/fxC9/30TLSsFsVUFELpPtp/BBgwahZ8+eGD9+PDw9PXMjT25LrZBjXMtIfLzW8TxKJhNbR8GDbbKJiMgNWc9nNnLjUc5nRkR5TrYDpcuXL+ODDz5gkJRN2gw9lh08h+41SkIIZNome3zLSPSrG8422URE5LY4nxkR5XXZvhM1adIEBw8eRMmSJXMjP24rTW9A3xUHMGn7X1m2yb7zOAPpegMDJSIicntPB0WsQSKivCTbgVKLFi0wePBg/PXXX6hUqRKUSqXF+latWuVY5tzF05PNnr7xABXHb0CjsoE2bbL3/H0T3RbtQ+LJqxjTIhIDG5TlWzUiIiIiIhfI9lN47969AQCjR4+2WSdJEgwGw/Pnys1YTzYrBLDtxFVsO3HV4TacbJaIiIiIyHWyHShZDwdOWeNks0REREREL5ccexK/ffs2pk2bllO7cyv/TjbrPNNks0RERERE9OI9V6AkhMDWrVvRoUMHBAUFYdy4cTmVL7dimmw2OzjZLBERERGR6zxToHTu3Dl8/vnnCA0NRfPmzeHh4YGNGzfi2rVrOZ0/t2CabNbZpnScbJaIiIiIyLWcDpTS09OxbNkyNGjQAOXKlcPx48cxdepUyGQyfPrpp2jYsCHkcg7r6YiHQo7xrSKdSsvJZomIiIiIXMvpKovg4GCUL18e77zzDlatWgU/Pz8AQMeOHXMtc+5Eo1Kgf0wZSJAwJCHZ4WSzE1pFIT46nHNJEBERERG5kNOBksFggCRJkCSJNUfPSALQuVpxdK5W3OFks6Z0RERERETkOk4HSlevXsXq1asxZ84cfPjhh2jWrBneeecdSBIf652hzdBjxp4UfLz2cJaTzU5u8xr61S0NjYp9lIiIiIiIXMHpJ3EPDw907twZnTt3xt9//4158+bhgw8+gF6vx7hx49C9e3fUr1+ftU0OpOkNGJpwxKnJZockJKNnrTBkc0RxIiKil4ZWp4dckqCQy6A3GGEQgoMYEVGe8kwjBoSFhWHs2LE4f/48Nm7ciPT0dMTFxSEgICCn8+cWtDo9ZuxOcXpeJJ3BiJm7U6DV6XM5Z0RERC+WNkOPu48z8OWOE6gxZSvCRq5DjSlb8eWOE7j7OAPaDP72EVHe8FyvbmQyGZo1a4ZmzZrh5s2bWLRoUU7ly63IJQmrky9ma5vVyRfwUcNyuZQjIiKiFy9db8CMPSkYmnDE6uXhIyRfuovRm49jfKtI9I8pw0GNiMjlcmwM6sKFC2PgwIHZ2mbChAmoVq0a8uXLB39/f7Rp0wanTp2ySCOEwMiRIxEUFASNRoPY2Fj8+eefOZXtF0IhlyFVm5GtbVK1OqfnXSIiIsrrtBl6TE86hcFrDjtsYaEzGDF4zWF8k5TCmiUicjmXPoknJSUhPj4e+/fvR2JiIvR6PRo3boxHjx6Z03zxxReYOnUqvvnmGxw4cABFihRBo0aN8ODBAxfmPHv0BiN8s9nhyFejdLqpHhERUV5n6qvrjCEJyUjT8zeQiFzLpYHSli1b0L17d1SoUAGRkZGYN28eLly4gEOHDgF4Ups0bdo0DBs2DO3atUPFihWxYMECPH78GEuXLv3/9u48Pqrq/v/4ezIzmUxkl0KIBKRIAKUmIMqiJCyCouy0WrUixboURCgu/VLrz4AKotavXwVpbRW0LWorUHFDFmVREFEJmwtQgxEkIJgQhCGznd8fMQO5SSAJE2bh9Xw88nhk7pYz88mdzDvn3HMj2fQaCRijkZlpNdpnZGYrBY2poxYBAHD6cK0ugFgUVdPLHDx4UJLUpEkTSVJeXp4KCgo0YMCA0DYul0vZ2dlas2aNbrvttgrHKCkpUUlJSehxcXGxJMnn88nn89WqXWX71XZ/h6Tbev5Ujy3ZUq0/Ek57gm7t2UYOmVr/TFR0qnVE9KCW8YE6xo+T1TLoD+iNTfly1+Cyo9c3fa2J2efJJ/5peLpwTsYPalm1mrwmNmOio9vCGKOhQ4eqsLBQq1evliStWbNGl156qXbv3q3U1NTQtrfeequ+/vprvfPOOxWOk5OToylTplRYPm/ePCUnJ9fdEwAAAAAQ1Y4cOaLrr79eBw8eVIMGDU64bY17lAKBgObOnavly5dr3759CgbL95C8++67NT2kJOmOO+7Qpk2b9P7771dYZ72prTGmyhvdTp48udykEsXFxUpLS9OAAQNO+mJUxefzaenSperfv7+cTmetjiFJXn9Af/lgh6a8tbnSniWnPUEPXPUz3XbpeUpktp+wC1cdEXnUMj5Qx/hxslp6/QH1e3q5Nu0uqvYxLzynkZaP78ffw9OIczJ+UMuqlY02q44aB6UJEyZo7ty5uvrqq9WpU6cqA0tNjB8/XosWLdKqVavUsmXL0PKUlBRJUkFBgVq0aBFavm/fvirv2eRyueRyuSosdzqdp/yLcqrHcDqd+m1WB/26Z7qeWbVN83PzVeTxqZHbqZGZrTQ2K11JjgS5E6NqRGTcCcfvAqIDtYwP1DF+VFVLv2wadGErrcsvqvaxBl/YWgkOh5zchPa045yMH9Syopq8HjV+93n55Zf1r3/9S1dddVVNd63AGKPx48dr4cKFWrFihdq0aVNufZs2bZSSkqKlS5eqc+fOkiSv16uVK1dqxowZp/zzI8Gd6JA7UZrUr4PuvryjnPYE+QJBBbkjOQAgTrmdDo3LStfUt6t/re7YrHT+LgKIqBrPepeYmKjzzjsvLD983Lhx+sc//qF58+apfv36KigoUEFBgTwej6TSIXcTJ07UtGnTtHDhQm3ZskWjR49WcnKyrr/++rC0IVLcTodcDrsSbDa5HHb+GAAA4lqSw65pQzKqte0jQzOV5OBeggAiq8bvQnfddZf+7//+T+GYA2L27Nk6ePCgevfurRYtWoS+XnnlldA29957ryZOnKixY8eqa9eu2r17t5YsWaL69euf8s8HAACnhzvRofHZ7fX48C5V3lDdaU/Q48O7aFxWOsPQAURctd6FRowYUe7xu+++q7ffflsXXHBBhXF+CxYsqPYPr07YstlsysnJUU5OTrWPCwAAoo/LYdfYXu00pkfbE16r62ICBwBRoFpBqWHDhuUeDx8+vE4aAwAA4hvX6gKIFdV6R5ozZ05dtwMAAJxBjg9F9CABiEY1vkapb9++KioqqrC8uLhYffv2DUebAAAAACCiahyUVqxYIa/XW2H50aNHtXr16rA0CgAAAAAiqdqDgTdt2hT6/rPPPlNBQUHocSAQ0OLFi3XOOeeEt3UAAAAAEAHVDkqZmZmy2Wyy2WyVDrFzu916+umnw9o4AAAAAIiEagelvLw8GWP005/+VB999JF+8pOfhNYlJiaqWbNmstu5GBMAAABA7Kt2UGrdurUkKRgM1lljAAAAACAaVCsoLVq0SAMHDpTT6dSiRYtOuO2QIUPC0jAAAAAAiJRqBaVhw4apoKBAzZo107Bhw6rczmazKRAIhKttAAAAABAR1QpKxw+3Y+gdAAAAgHhX4/soAQAAAEC8q/ZkDsdbvny5li9frn379lXoYXr++efD0jAAAAAAiJQaB6UpU6Zo6tSp6tq1q1q0aCGbzVYX7QIAAACAiKlxUPrzn/+suXPn6sYbb6yL9gAAAABAxNX4GiWv16uePXvWRVsAAAAAICrUOCj95je/0bx58+qiLQAAAAAQFWo89O7o0aN69tlntWzZMl144YVyOp3l1j/xxBNhaxxKeXx+2W02OewJ8geCChgjt7NW83AAAAAAqIYaf9retGmTMjMzJUlbtmwpt46JHcLL4/XrqD+oWau+1Pzcb1Tk8aqRO1EjM9M0Lqu9khwJcicSmAAAAIBwq/Gn7Pfee68u2gGLEn9As1Zv0x8WbZQvcPwU7IeVu6tQU9/eomlDMjQ+u71cDnvE2gkAAADEo1rfcHbHjh1655135PF4JEnGmLA16kzn8fr19Movdc/CDZaQdIwvENQ9Czdo5spt8nj9p7mFAAAAQHyrcVA6cOCA+vXrp/T0dF111VXas2ePpNJJHu66666wN/BMdNQf0B8WbazWtpMX5eqov/IwBQAAAKB2ahyUfve738npdCo/P1/Jycmh5ddee60WL14c1sadiTw+v2at2lZlT5KVLxDUM6u2yeOjVwkAAAAIlxoHpSVLlmjGjBlq2bJlueXt2rXT119/HbaGnansNpvm535To33m5+YrgYk0AAAAgLCpcVA6fPhwuZ6kMvv375fL5QpLo85kDnuCijzeGu1T5PHJaa/15WYAAAAALGr86TorK0svvvhi6LHNZlMwGNRjjz2mPn36hLVxZyJ/IKhG7sQa7dPI7az2UD0AAAAAJ1fj6cEfe+wx9e7dWx9//LG8Xq/uvfdebd26Vd9//70++OCDumjjGSVgjEZmpil3V2G19xmZ2UpBZh0EAAAAwqbGPUrnn3++Nm3apEsuuUT9+/fX4cOHNWLECG3YsEFt27atizaeUdxOh8ZlpVd7KJ3TnqCxWelyO7nxLAAAABAutfp0nZKSoilTpoS7LfhRksOuaUMydM/CDSfd9pGhmUpycH0SAAAAEE7V/oTdr18/LViwoMr1+/fv109/+tOwNOpMZ0+w6dZL22nG0M5V9iw57Ql6fHgXjctKlzuR3iQAAAAgnKr9Cfu9997TypUrdd9991XamxQIBJgePAw8Xr9mrd6mZz/Yof/ckq1R3drorx/s0MKN36jI41Mjt1PDM9J0y6XnSZJMkGuTAAAAgHCrUVfE7Nmzdc8992jTpk36+9//rnr16tVVu85YR/0B/WHRRvkCQXWa9ob6d2ihcVnpuiM7XfVdTh0q8Wn1f7/TTX9fqxXb96pg2kgl1WySPAAAAAAnUaOgNHToUF122WUaNmyYevTooddee43hdmHk8fk1a9W20FTfxkhLPt+jJZ/vqXKfZ1Zt06R+HZjMAQAAAAijGs8C0LFjR3300UdKS0vTxRdfrGXLltVFu+KSx+eX1x9Q0Bh5/QF5fP5y6+02m+bnflOjY87PzVeCzRbOZgIAAABnvFp1QzRs2FBvvvmmJk+erKuuukozZszQ9ddfH+62xQ2P16+j/qBmrfpS83O/UZHHq0buRI3MTNO4rPZKciTIneiQw56gIo+3Rscu8viqPZU4AAAAgOqpdlCyWXotbDabHnnkEXXu3Fk333yz3n333bA3Lh6U+AOatXpb6LqjYw4rd1ehpr69RdOGZGh8dnvZJDVyJ0o6XO3jN3I75QsE5XLYw910AAAA4IxV7a4IYyqfXe3aa6/V+++/r82bN4etUfHC4/Xr6ZVf6p6FGywh6RhfIKh7Fm7QzJWl1yaNzEyr0c8YmdlKwSpqAwAAAKB2qh2U3nvvPTVp0qTSdZmZmfrkk080Z86csDUsHpTNYFcdkxflKmikcVnp1R5K57QnaGxWOhM5AAAAAGFW7aCUnZ0th6PqD+Rnn322Ro0aFZZGxQPrDHYn4wsE9dSKL+Vy2DVtSEa19nlkaKaSHFyfBAAAAIQbn7LrSG1nsHMk2DQ+u70eH96lyp4lpz1Bjw/vonFZ6XIn0psEAAAAhBufsutIbWewc9gTlGCzaWyvdhrTo62eWbVN83PzVeTxqZHbqZGZrTQ2K11JjgQmcAAARBWvPyC7wyF/IKiAMQwNBxDTeAerI/5A8JRmsHMnOuROlCb166C7L+8opz1BvkBQQf7wAACiiMfr1w9HS/8x2O/p5dp72FfpLTAAINYw9K6OBIwJywx2bqdDLoddCTZbaYAiJAEAokTZLTDOy1kkSdq0u0g7D5Te/uL+Nzap+eT5mrV6m0r8gQi3FABqjqBUR9xOBzPYAagVj88vrz+goDFauny5Jk6aFFr35z//WXPnzpXNZtMrr7wiSfriiy80evRoSdLo0aO1ZcsWSdKdd96pBx98UDt37pTNZtO6deskSYsXL1ZOTo4kqbCwUNddd52ys7N12WWXacWKFZKkm2++ObT9448/rhEjRkiSAoGAOnfuLEk699xzNWPGDEnS0aNH1bt37zp7TRB9anoLDI/Xf5pbCACnhqBUh5KYwQ5ADXi8fhUe8epPyz9Xt8ffUduc1/TbV9br468PqPCIt9wHzTZt2mjmzJlVHmvq1Kmy2Wy6//77JUnnn3++Hn300QrbjR8/XqNGjdLKlSv16quvaty4cfr+++/VvXv3UFDauPHYbQ62bNmiTp06SZIaNWqk+fPnq6SkJCzPH7GlprfAOOqv3iywABAt+GReh9yJDmawA1AtZUOYmk+er/vf2KTcXYXaeeCw/vvdIX3w1f7QECb/j/+5b9KkiTIzM7VkyZIKx5o9e7Z27NihJ598MrSsY8eO8vv9+uKLL0LLAoGAtm3bpoEDB0qSUlJSNHz4cL355pvq1q2bPvzwQ0mlvUVt27ZVfn6+PvzwQ3Xv3l2S5HA4dO211+qFF16oq5cFUao2t8B4ZtU2eXz0KgGIHQSlOuZy2DW2VzvtnT5SDw3KUOeWjdXm7Hrq3LKxHhqUob3TR2psr3bMYAecwWoyhOm97Xvl/fF6j7vuukt/+tOfKmw7b9483XnnnbLZbOWW33PPPXrsscdCj/fv36/mzZuX2yYtLU3ffvutOnXqpM8++0x79+5VixYtdMkll2jdunVat25dKChJ0q233qq//e1vCgbpLTiT1PYWGAmW30kAiGYEpdPAnehQ4+RETerXQWvvvkI7coZo7d1XaFK/DmqcnEhPEnCGO+EQJnuiFPCFHv7n0zzZE5MklV4j1LRpU61fv77cLs8995zGjBmjXbt2lVt+2WWXKS8vT7t375YkNW3aVPv27Su3za5du5SamqqEhAQ1adJEb7zxhi655JJQUNq0aZMyMo4NKa5fv7769++v+fPn1/r5I/bU9hYY1b1uFwCiAe9YpxEz2AGwOukQpkYp0nc7pR97bILffqmNnrNCM2Tee++9Fa49Sk9P16xZszRixAgdOnSo3LqJEyeGhuTZ7Xa1a9cuNHxv7969Wrhwoa6++mpJUrdu3fT000+rW7duat26tTZu3Kh69erJ4Sj/3jVhwgQ99dRTp/IyIMYcuwVG9ZXdAgMAYgVBCQAi6KRDmJLqSR2ypIUPSgumSk1b6f3CRNlUOoQpIyNDLVu2rLBbr169NGHCBF1zzTXy+49dFzJ48GAFAseman766ac1Z84c9e7dWyNHjtTMmTPVpEkTSaVBKT8/X+3atSttSlKSLr744go/q1mzZuratWutnj9iU7hugQEA0YwuDQCIoGoNYbqgT+nXj4o8Pu34+Nhwu7fffjv0/dy5c0Pf33DDDbrhhhskSa+++qokyWaz6bPPPgtt07hxY7300kuV/thhw4Zp2LBhocevv/56ufUff/xx6PvZs2ef+DkgrpTdAmPq21uq1UvELTAAxCJ6lAAgghjChFjFLTAAxDvetQAgghjChFjFLTAAxDvetQAgghjChFhWdguMURe30pr3lunCcxpp32G/GrmdGpnZSmOz0pXkSOAWGABiEn9pASDCyoYw3bNww0m3ZQgToo070SGHrbSHc/n4fnInueQLBBU0hkAPIKbxDgYAEVY2hMkmmyYvyq20Z8lpT9D0IZkal5XOf+cRtRKPuwUGAMQ6/i15mnh8fnn9AX2VlyebzaaVH3wgSVq8eLFycnIkSUVFRRo9erR69+6tXr166bbbbpP58TqEhQsXKjs7W7169dJVV10VumFkmREjRqh3797Kzs5W48aNJUkPP/ywevbsqW7duumFF16QJBUXF2vIkCHq06eP7rrrLknS/v37demllyo7O1t9+vTRt99+ezpeEgDHKRvCtHf6SD00KEOdWzZWm7PrqXPLxnpoUIb2Th+psb3a8QEUAIDThB6lOubx+nXUH9SsVV9qfu43+m7PLiU1a6Wxv39A7y95SyW+Y/czGT9+vK677jpdddVVkqTVq1fLGKMvv/xSs2fP1uLFi+V2u/XVV1/J6y0/nfCCBQskSe+//76ee+45SdJ1112n++67T16vV126dNGoUaP0l7/8RUOHDtXNN9+ssWPHat26deratatWrVolu92uF154Qc8995zuv//+0/QKASjjTnTInShN6tdBd1/eUU57AkOYAACIEP7y1qESf0CzVm/THxZtPDaUpviIVL+5PttdqGa3PaWbzq+vlGBQgUBAO3bsCIUkqfSGkZL0r3/9S+PHj5fb7ZYk/fSnP63yZ/773//WL37xi3LbOZ1OORylpf7qq6/Ut29fSVKXLl20evVqdevWLbR/cXGxOnXqFKZXAEBtHB+K6EECACAyGHpXRzxev55e+aXuWbih8pmsOl8t/ydv6Lk1/9VHOw/om28L1LRp09Dq3r17q1OnTtq2bZv27Nmj1NTUk/5MY4yWL1+uyy+/vNzyp556Stdcc41sNps6duyod999V5K0bNkyFRUVSZI2b96sbt26aebMmercuXPtnzgAAAAQBwhKdeSoP6A/LNpY9Qap7aXi76TDhVr+ZYHqNWqi7777LrR6xYoV6tq1q7xer1JTUytck1SZNWvWqGvXrkpMPHbzyqVLl2rlypX6n//5H0nSb37zG23dulWXX3656tWrp5SUFEnSz372M61bt04PPvigHnnkkVo+awAAACA+EJTqgMfn16xV205+T5SMK6SNixU0Rn/54L/6adu2euutt0Kr/X6/JOmaa67RzJkz5fF4JEk7d+5UXl5ehcMdP+xOkrZu3aoHH3xQL774ohISSkudnJysuXPnatmyZZKkQYMGlbveqWHDhjrrrLNq98QBAACAOME1SnXAbrNpfu43J9/w3C7S2lckSfNz8/XWk/+n3999l2bMmKGkpCS1adNG5557rurVq6fbb79dV1xxhSSpQYMGevbZZ8sdyhijZcuW6dFHHw0tmzRpkg4cOKBBgwZJkl577TXl5eVp4sSJstvtGjVqlM4991x98skn+t3vfie73a7k5OTQZBAAAADAmYoepTrgsCeoyOOtfGWDn0hXTij93maTrn9UumSkijw+NWt6tl544QWtXLlS77zzjv736ZlKTHIraIzqN2yoLj/OTvfGG29o0aJFmjt3rmw2m1555RXZbDa9+uqruvXWWyVJo0eP1p/+9Cdt3bpVF154ofr166fCwkJ17txZM2bM0PLly9W8eXPl5OTooosu0muvvaaUlBT98MMP+vnPf64VK1ZIkm6++WatW7dOkvT4449rxIgRkqRAIBC6luncc8/VjBkzJElHjx5V79696+aFBQAAAE4TglId8AeCauROPPmGx2nkdoaG6nm8fhUe8epPyz9Xt8ffUduc1/TbV9br468PqPCIVx6vP7RfmzZtNHPmzCqPO3XqVNlsttB03+eff365Xqcy48eP16hRo7Ry5Uq9+uqrGjdunL7//nt17949FJQ2bjx2zdWWLVtCs+M1atRI8+fPV0lJSY2eMwAAABCtCEp1IGCMRmam1WifkZmtZIwJTSnefPJ83f/GJuXuKtTOA4f13+8O6YOv9qv55PmatXqb/D+GqiZNmigzM1NLliypcMzZs2drx44devLJJ0PLOnbsKL/fry+++OJYewMBbdu2TQMHDpQkpaSkaPjw4XrzzTfVrVs3ffjhh5JKe4vatm2r/Px8ffjhh+revbskyeFw6Nprrw3d1BYAAACIdQSlOuB2OjQuK11Oe/VeXqc9QWOz0mWMTjyluCRfIKh7Fm7Qe9v3yusvvVntXXfdpT/96U8Vtp03b57uvPNO2Wy2csvvuecePfbYY6HH+/fvV/Pmzcttk5aWpm+//VadOnXSZ599pr1796pFixa65JJLtG7dOq1bty4UlCTp1ltv1d/+9jcFgyeZwAIAAACIAQSlOpLksGvakIxqbfvI0EwlO+0nnlLcnigFfKGH//k0T/bEJEml1wg1bdpU69evL7fLc889pzFjxmjXrl3lll922WXKy8sLTTnetGlT7du3r9w2u3btUmpqqhISEtSkSRO98cYbuuSSS0JBadOmTcrIOPb86tevr/79+2v+/PnVes4AAABANCMo1RF3okPjs9vr8eFdquxZctoT9PjwLhqXla6gzImnFG+UIn23U/qxxyb47Zfa6DlLQWMkSffee2+Fa4/S09M1a9YsjRgxQocOHSq3buLEiaEheXa7Xe3atQsN39u7d68WLlyoq6++WpLUrVs3Pf300+rWrZtat26tjRs3ql69enI4yk+aOGHCBD311FPVfo0AAACAaEVQqkMuh11je7XT3ukj9dCgDHVu2Vhtzq6nzi0b66FBGdo7faTG9monl8N+8inFk+pJHbKkhQ9KC6ZKTVvp/cJE2VQ6rC4jI0MtW7assFuvXr00YcIEXXPNNaH7MknS4MGDFQgEQo+ffvppzZkzR71799bIkSM1c+ZMNWnSRFJpUMrPz1e7du1Km5KUpIsvvrjCz2rWrJm6du1aq9cKAAAAiCbcR6mOuRMdcidKk/p10N2Xd5TTniBfIKigMXI7j738J5xSvMwFfUq/flTk8WnHx8eG27399tuh7+fOnRv6/oYbbtANN9wgSXr11VclSTabTZ999llom8aNG+ull16q9McOGzZMw4YNCz1+/fXXy63/+OOPQ9/Pnj37xM8BAAAAiAEEpdPk+FDkctgrrD82pfjhah+zbErxyo4HAAAAoPYYehclajuleNk1SgAAAADCh6AUJWo7pfjxPVUAAAAAwoOgFEVqOqV4koPyAQCii8fnl9cfUNAYef0BeXz+k+8EAFGI7ogoUjaluE02TV6UW+lU4U57gqYPydS4rHSuTQIARJUij1d/WfOV5ud+oyKPV43ciRqZmaZxWe2V5EiQO5GPHQBiR0S7JFatWqXBgwcrNTVVNptN//nPf8qtHz16tGw2W7mv7t27R6axp0lNphQHACAaeP2lt5s4L2eR7n9jk3J3FWrngcPK3VWo+9/YpOaT52vW6m0q8QdOciQAiB4R/dfO4cOHlZGRoV//+tcaOXJkpdtceeWVmjNnTuhxYmLi6WpexFR3SnEAACLN4/XrLx9sV1upypum+wJB3bNwg2yyaWyvdvQsAYgJEX2nGjhwoAYOHHjCbVwul1JSUk5Ti6LLyaYUBwAg0o76A5ry1ha9mJ180m0nL8rVmB5t5Y7//3kCiANRPxvAihUr1KxZM6Wnp+uWW27Rvn37It0kAACg0okbZq3aVmVPkpUvENQzq7YxwQOAmBDVfd8DBw7UL37xC7Vu3Vp5eXm6//771bdvX33yySdyuVyV7lNSUqKSkpLQ4+LiYkmSz+eTz+erVTvK9qvt/ogO1DF+UMv4QB1jX9Af0Bub8uX+cdCDuxqDH17f9LUmZp8nn7gPYLThnIwf1LJqNXlNbMZExx1LbTabFi5cqGHDhlW5zZ49e9S6dWu9/PLLGjFiRKXb5OTkaMqUKRWWz5s3T8nJJx8WAAAAACA+HTlyRNdff70OHjyoBg0anHDbqO5RsmrRooVat26t7du3V7nN5MmTNWnSpNDj4uJipaWlacCAASd9Mari8/m0dOlS9e/fX06ns1bHQORRx/hBLeMDdYx9Xn9A/Z5eru0FRXo+u57GrPxBnpNMbHfhOY20fHw/JXLtbdThnIwf1LJqZaPNqiOmgtKBAwf0zTffqEWLFlVu43K5Kh2W53Q6T/kXJRzHQORRx/hBLeMDdYxdftk06MJWmra7SJLkCeikQWnwha2V4HDIySyuUYtzMn5Qy4pq8npEdDKHH374Qbm5ucrNzZUk5eXlKTc3V/n5+frhhx909913a+3atdq5c6dWrFihwYMHq2nTpho+fHgkmw0AAFQ6O+u4rHQ57dX7OOG0J2hsVjq3ugAQEyL6TvXxxx+rT58+ocdlQ+ZuuukmzZ49W5s3b9aLL76ooqIitWjRQn369NErr7yi+vXrR6rJAADgOEkOux64qpN0+CvZbNIVHVtobFa6sto2U/0khw4d9WvVf/fpmVXbNKBjCyU5on7CXQCQFOGg1Lt3b51oLol33nnnNLYGAADUlDvRodsubadlS77Sh3dfqZ80SNazH+zQA29uUpHHq0buRA3PSNM/buqp5EQHN5sFEDN4twIAAKekbGKGpV98q/95fYvlvkqHlburUA8t3qJpQzI0Prs9N1EHEBMISgAA4JQc9ZbeQPaPr2+Sr4rJHHyBoO5ZuEE22TS2Vzt6lgBEPQYKAwCAU3K0XA/SiU1elKuj/upvDwCRQlACAAC15vH59dcPdlR7e18gqGdWbZPH56/DVgHAqSMoAQCAWrPbbFq0eVeN9pmfm68Em62OWgQA4UFQAgAAteawJ6jI46vRPkUeX7XvvQQAkcK7FAAAqDV/IKhG7urf6V6SGrmdlpnxACD6EJQAAECtBYzRkJ+1rNE+IzNbKXiC+ygCQDQgKAEAgFpzOx265dLzqr29056gsVnpcjuZHhxAdCMoAQCAU5JUg+uNHhmaqSQHHz8ARD/eqQAAwClJ+vHmsQ8NzqhykganPUGPD++icVnp3GwWQEzgnQoAAITFLT3a6tc90/XMqm2an5uvIo9PjdxOjcxspbFZ6UpyJMjlsEe6mQBQLQQlAAAQFkmJDjmdTk3q10F3X95RTnuCfIGggsZwTRKAmMO7FgAACKvjQxE9SABiFdcoAQAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAAADAgqAEAAAAABYEJQAAAACwICgBAAAAgAVBCQAAAAAsCEoAAAAAYEFQAgAAAAALghIAAAAAWBCUAAAAAMCCoAQAAAAAFgQlAAAAALAgKAEAAACABUEJAAAAACwISgAAAABgQVACAAAAAAuCEgAAAABYEJQAAAAAwIKgBAAAAAAWBCUAAAAAsCAoAQAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAAADAgqAEAAAAABYEJQAAAACwICgBAAAAgAVBCQAAAAAsCEoAAAAAYEFQAgAAAAALghIAAAAAWBCUAAAAAMCCoAQAAAAAFgQlAAAAALBwRLoBAAAgfnl8ftltNjnsCfIHggoYI7eTjx8Aoh/vVAAAIOw8Xr+O+oOatepLzc/9RkUerxq5EzUyM03jstoryZEgdyIfQwBEL96hAABAWJX4A5q1epv+sGijfIHgcWsOK3dXoaa+vUXThmRofHZ7uRz2iLUTAE6EoAQAAMLG4/Vr1uptumfhhiq38QWCumfhBtlk09he7ehZAhCVmMwBAACEzVF/QH9YtLFa205elKuj/uDJNwSACCAoAQCAsDjq82vWqm2W4XZV8wWCembVNnl8/jpuGQDUHEEJAACERYLNpvm539Ron/m5+Uqw2eqoRQBQewQlAAAQFg57goo83hrtU+TxyWnn4wiA6MM7EwAACAt/IKhG7sQa7dPI7az2UD0AOJ0ISgAAICyCxmhkZlqN9hmZ2UpBY+qoRQBQewQlAAAQFklOh8ZlpVd7KJ3TnqCxWelyO5keHED0ISgBAICwSXLYNW1IRrW2fWRoppIcfBQBEJ34Fw4AAAgbd6JD47PbyyabJi/KrfT6I6c9QdOHZGpcVrpcDnsEWgkAJ0dQAgAAYeVy2DW2VzuN6dFWz6zapvm5+Sry+NTI7dTIzFYam5WuJEcCIQlAVCMoAQCAsHMnOuROlCb166C7L+8opz1BvkBQQWO4JglATOCdCgAA1JnjQxE9SABiCVdQAgAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAAADAgqAEAAAAABYRDUqrVq3S4MGDlZqaKpvNpv/85z/l1htjlJOTo9TUVLndbvXu3Vtbt26NTGMBAAAAnDEiGpQOHz6sjIwMzZw5s9L1jz76qJ544gnNnDlT69evV0pKivr3769Dhw6d5pYCAAAAOJM4Tr5J3Rk4cKAGDhxY6TpjjJ588kndd999GjFihCTphRdeUPPmzTVv3jzddtttp7OpAAAAAM4gUXuNUl5engoKCjRgwIDQMpfLpezsbK1ZsyaCLQMAAAAQ7yLao3QiBQUFkqTmzZuXW968eXN9/fXXVe5XUlKikpKS0OPi4mJJks/nk8/nq1Vbyvar7f6IDtQxflDL+EAd4we1jA/UMX5Qy6rV5DWJ2qBUxmazlXtsjKmw7HjTp0/XlClTKixfsmSJkpOTT6ktS5cuPaX9ER2oY/yglvGBOsYPahkfqGP8oJYVHTlypNrbRm1QSklJkVTas9SiRYvQ8n379lXoZTre5MmTNWnSpNDj4uJipaWlacCAAWrQoEGt2uLz+bR06VL1799fTqezVsdA5FHH+EEt4wN1jB/UMj5Qx/hBLatWNtqsOqI2KLVp00YpKSlaunSpOnfuLEnyer1auXKlZsyYUeV+LpdLLperwnKn03nKvyjhOAYijzrGD2oZH6hj/KCW8YE6xg9qWVFNXo+IBqUffvhBO3bsCD3Oy8tTbm6umjRpolatWmnixImaNm2a2rVrp3bt2mnatGlKTk7W9ddfH8FWAwAAAIh3EQ1KH3/8sfr06RN6XDZk7qabbtLcuXN17733yuPxaOzYsSosLFS3bt20ZMkS1a9fP1JNBgAAAHAGiGhQ6t27t4wxVa632WzKyclRTk7O6WsUAAAAgDNe1N5HCQAAAAAihaAEAAAAABYEJQAAAACwICgBAAAAgAVBCQAAAAAsCEoAAAAAYEFQAgAAAAALghIAAAAAWBCUAAAAAMCCoAQAAAAAFgQlAAAAALAgKAEAAACABUEJAAAAACwISgAAAABgQVACAAAAAAuCEgAAAABYEJQAAAAAwIKgBAAAAAAWBCUAAAAAsCAoAQAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAAADAgqAEAAAAABYEJQAAAACwICgBAAAAgAVBCQAAAAAsCEoAAAAAYEFQAgAAAAALghIAAAAAWBCUAAAAAMCCoAQAAAAAFgQlAAAAALAgKAEAAACABUEJAAAAACwISgAAAABgQVACAAAAAAuCEgAAAABYEJQAAAAAwIKgBAAAAAAWBCUAAAAAsCAoAQAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAAADAgqAEAAAAABYEJQAAAACwICgBAAAAgAVBCQAAAAAsCEoAAAAAYEFQAgAAAAALghIAAAAAWBCUAAAAAMCCoAQAAAAAFgQlAAAAALAgKAEAAACABUEJAAAAACwISgAAAABgQVACAAAAAAuCEgAAAABYEJQAAAAAwIKgBAAAAAAWBCUAAAAAsCAoAQAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAAADAgqAEAAAAABYEJQAAAACwICgBAAAAgAVBCQAAAAAsojoo5eTkyGazlftKSUmJdLMAAAAAxDlHpBtwMhdccIGWLVsWemy32yPYGgAAAABngqgPSg6Hg14kAAAAAKdVVA+9k6Tt27crNTVVbdq00S9/+Ut99dVXkW4SAAAAgDgX1T1K3bp104svvqj09HTt3btXDz30kHr27KmtW7fq7LPPrnSfkpISlZSUhB4XFxdLknw+n3w+X63aUbZfbfdHdKCO8YNaxgfqGD+oZXygjvGDWlatJq+JzRhj6rAtYXX48GG1bdtW9957ryZNmlTpNjk5OZoyZUqF5fPmzVNycnJdNxEAAABAlDpy5Iiuv/56HTx4UA0aNDjhtjEVlCSpf//+Ou+88zR79uxK11fWo5SWlqb9+/ef9MWois/n09KlS9W/f385nc5aHQORRx3jB7WMD9QxflDL+EAd4we1rFpxcbGaNm1araAU1UPvrEpKSvT555+rV69eVW7jcrnkcrkqLHc6naf8ixKOYyDyqGP8oJbxgTrGD2oZH6hj/KCWFdXk9YjqyRzuvvturVy5Unl5eVq3bp1+/vOfq7i4WDfddFOkmwYAAAAgjkV1j9KuXbt03XXXaf/+/frJT36i7t2768MPP1Tr1q0j3TQAAAAAcSyqg9LLL78c6SYAAAAAOANF9dA7AAAAAIgEghIAAAAAWBCUAAAAAMCCoAQAAAAAFgQlAAAAALAgKAEAAACABUEJAAAAACwISgAAAABgQVACAAAAAAuCEgAAAABYEJQAAAAAwIKgBAAAAAAWBCUAAAAAsCAoAQAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAAADAgqAEAAAAABYEJQAAAACwICgBAAAAgAVBCQAAAAAsCEoAAAAAYEFQAgAAAAALghIAAAAAWBCUAAAAAMCCoAQAAAAAFgQlAAAAALAgKAEAAACABUEJAAAAACwISgAAAABgQVACAAAAAAuCEgAAAABYEJQAAAAAwIKgBAAAAAAWBCUAAAAAsCAoAQAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAAADAgqAEAAAAABYEJQAAAACwICgBAAAAgAVBCQAAAAAsCEoAAAAAYEFQAgAAAAALghIAAAAAWBCUAAAAAMCCoAQAAAAAFgQlAAAAALAgKAEAAACABUEJAAAAACwISgAAAABgQVACAAAAAAuCEgAAAABYEJQAAAAAwIKgBAAAAAAWBCUAAAAAsCAoAQAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAAADAgqAEAAAAABYEJQAAAACwICgBAAAAgAVBCQAAAAAsCEoAAAAAYEFQAgAAAAALghIAAFHscIlPJf6AgsaoxB/Q4RJfpJsEAGcER6QbAAAAKjri9avEH9TMlV9qwcZvVOTxqpE7USMy0nRHdnu5HAlKTuTPOADUFd5hAQCIMkd9Ac1atU33vb5RvkDwuDWHlburUA8u3qKHB2fozuz2cjntEWsnAMQzghIAAFHkiNevWau26d7/bKhyG18gqHv/s0E2SWOz0ulZAoA6EBPXKD3zzDNq06aNkpKSdNFFF2n16tWRbhIAAHXiqC+g+17fWK1t//D6RpX4gyffEABQY1EflF555RVNnDhR9913nzZs2KBevXpp4MCBys/Pj3TTAAAIq8MlPs1atc0y3K5qvkBQs1Z9yQQPAFAHoj4oPfHEE7r55pv1m9/8Rh07dtSTTz6ptLQ0zZ49O9JNAwAgrBz2BC3Y+E2N9lmQ+40c9qj/cw4AMSeq31m9Xq8++eQTDRgwoNzyAQMGaM2aNRFqFQAAdcNpT1CRx1ujfYo8PjkJSgAQdlF99ef+/fsVCATUvHnzcsubN2+ugoKCSvcpKSlRSUlJ6HFxcbEkyefzyeer3dCEsv1quz+iA3WMH9QyPlDHirz+gJqf5dTeourv0+wshzxHS5ToiNzsd9QyPlDH+EEtq1aT18RmjDF12JZT8u233+qcc87RmjVr1KNHj9Dyhx9+WH//+9/1xRdfVNgnJydHU6ZMqbB83rx5Sk5OrtP2AgAAAIheR44c0fXXX6+DBw+qQYMGJ9w2qnuUmjZtKrvdXqH3aN++fRV6mcpMnjxZkyZNCj0uLi5WWlqaBgwYcNIXoyo+n09Lly5V//795XQ6a3UMRB51jB/UMj5Qx8oVHvGq3ZRF1ZrQwWlP0I6cIWrkTjwNLasatYwP1DF+UMuqlY02q46oDkqJiYm66KKLtHTpUg0fPjy0fOnSpRo6dGil+7hcLrlcrgrLnU7nKf+ihOMYiDzqGD+oZXygjuXVc9v0x6syTngfpTJTB2forCSXnM7o+HNOLeMDdYwf1LKimrwe0fHOegKTJk3SjTfeqK5du6pHjx569tlnlZ+fr9tvvz3STQMAIOySEx26M7u9bCq9T1JlPUtOe4KmDc7Q+Oz2cjkjd20SAMSzqA9K1157rQ4cOKCpU6dqz5496tSpk9566y21bt060k0DAKBOuJx2jc1K1809z9OsVV9qQe43KvL41Mjt1IjMNI3Lai+XI4GQBAB1KOqDkiSNHTtWY8eOjXQzAAA4bZITHUpOlH7Xp4Puufx8Oe0J8gWC8geCOsvFUBoAqGsxEZQAADhTHR+KXA67XBGcBhwAziTcoQ4AAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAAADAgqAEAAAAABYEJQAAAACwICgBAAAAgAVBCQAAAAAsCEoAAAAAYEFQAgAAAAALghIAAAAAWBCUAAAAAMCCoAQAAAAAFgQlAAAAALAgKAEAAACABUEJAAAAACwISgAAAABgQVACAAAAAAuCEgAAAABYEJQAAAAAwIKgBAAAAAAWBCUAAAAAsCAoAQAAAIAFQQkAAAAALByRbkBdM8ZIkoqLi2t9DJ/PpyNHjqi4uFhOpzNcTcNpRh3jB7WMD9QxflDL+EAd4we1rFpZJijLCCcS90Hp0KFDkqS0tLQItwQAAABANDh06JAaNmx4wm1spjpxKoYFg0F9++23ql+/vmw2W62OUVxcrLS0NH3zzTdq0KBBmFuI04U6xg9qGR+oY/yglvGBOsYPalk1Y4wOHTqk1NRUJSSc+CqkuO9RSkhIUMuWLcNyrAYNGvDLFgeoY/yglvGBOsYPahkfqGP8oJaVO1lPUhkmcwAAAAAAC4ISAAAAAFgQlKrB5XLpgQcekMvlinRTcAqoY/yglvGBOsYPahkfqGP8oJbhEfeTOQAAAABATdGjBAAAAAAWBCUAAAAAsCAoAQAAAIBFTAel3bt361e/+pXOPvtsJScnKzMzU5988klovTFGOTk5Sk1NldvtVu/evbV169YKx1m7dq369u2rs846S40aNVLv3r3l8XhC6wsLC3XjjTeqYcOGatiwoW688UYVFRWVO8b69evVr18/NWrUSI0bN9aAAQOUm5t7wvaXlJRo/Pjxatq0qc466ywNGTJEu3btOqXXJBbFeh179+4tm81W7uuXv/zlKb0msSqaarl8+XL17NlT9evXV4sWLfT73/9efr//hO3nnCwV63XknDzmdNXy4YcfVs+ePZWcnKxGjRpV2pb8/HwNHjxYZ511lpo2bao777xTXq/3hO3nnCwV63XknDwmmmo5YcIEXXTRRXK5XMrMzKxW+8+4c9LEqO+//960bt3ajB492qxbt87k5eWZZcuWmR07doS2eeSRR0z9+vXN/PnzzebNm821115rWrRoYYqLi0PbrFmzxjRo0MBMnz7dbNmyxWzbts38+9//NkePHg1tc+WVV5pOnTqZNWvWmDVr1phOnTqZQYMGhdYXFxebxo0bm9GjR5svvvjCbNmyxYwcOdI0a9bMeL3eKp/D7bffbs455xyzdOlS8+mnn5o+ffqYjIwM4/f7w/xqRa94qGN2dra55ZZbzJ49e0JfRUVFYX6lol801XLjxo0mMTHRTJkyxWzfvt2sWLHCdOjQwdx1110nfA6ck/FRR87JUqezlv/v//0/88QTT5hJkyaZhg0bVmiL3+83nTp1Mn369DGffvqpWbp0qUlNTTV33HHHCZ8D52R81JFzslQ01dIYY8aPH29mzpxpbrzxRpORkVGt53CmnZMxG5R+//vfm8suu6zK9cFg0KSkpJhHHnkktOzo0aOmYcOG5s9//nNoWbdu3cwf//jHKo/z2WefGUnmww8/DC1bu3atkWS++OILY4wx69evN5JMfn5+aJtNmzYZSeV++Y9XVFRknE6nefnll0PLdu/ebRISEszixYtP8MzjS6zX0ZjSPwATJkw44fM8E0RTLSdPnmy6du1abr+FCxeapKSkcn9sjsc5WSrW62gM52SZ01XL482ZM6fSD2VvvfWWSUhIMLt37w4te+mll4zL5TIHDx6s9Fick6VivY7GcE6WiaZaHu+BBx6oVlA6E8/JmB16t2jRInXt2lW/+MUv1KxZM3Xu3Fl//etfQ+vz8vJUUFCgAQMGhJa5XC5lZ2drzZo1kqR9+/Zp3bp1atasmXr27KnmzZsrOztb77//fmiftWvXqmHDhurWrVtoWffu3dWwYcPQcdq3b6+mTZvqueeek9frlcfj0XPPPacLLrhArVu3rrT9n3zyiXw+X7n2paamqlOnTqHjnglivY5l/vnPf6pp06a64IILdPfdd+vQoUNheX1iSTTVsqSkRElJSeXa53a7dfTo0XJDHI7HOVkq1utYhnPy9NWyOtauXatOnTopNTU1tOyKK65QSUkJ5+RJxHody3BORlcta+NMPCdjNih99dVXmj17ttq1a6d33nlHt99+u+688069+OKLkqSCggJJUvPmzcvt17x589C6r776SpKUk5OjW265RYsXL1aXLl3Ur18/bd++PXScZs2aVfj5zZo1Cx2nfv36WrFihf7xj3/I7XarXr16euedd/TWW2/J4XBU2v6CggIlJiaqcePGVbbvTBDrdZSkG264QS+99JJWrFih+++/X/Pnz9eIESNO8ZWJPdFUyyuuuEJr1qzRSy+9pEAgoN27d+uhhx6SJO3Zs6fS9nNOlor1Okqck2VOVy2ro6CgoMLPady4sRITE6s8vzgnS8V6HSXOyTLRVMvaOBPPyao//UW5YDCorl27atq0aZKkzp07a+vWrZo9e7ZGjRoV2s5ms5XbzxgTWhYMBiVJt912m37961+HjrN8+XI9//zzmj59eqXHsB7H4/FozJgxuvTSS0N/0B9//HFdddVVWr9+vdxud7Wf1/HHPRPEQx1vueWW0PedOnVSu3bt1LVrV3366afq0qVLrV6XWBRNtRwwYIAee+wx3X777brxxhvlcrl0//336/3335fdbq/R8+KcjL06ck6WOp21rI6T1bu6OCdjr46ck6WirZbhEs/nZMz2KLVo0ULnn39+uWUdO3ZUfn6+JCklJUWSKiTcffv2hZJ6ixYtJOmkx9m7d2+Fn//dd9+FjjNv3jzt3LlTc+bM0cUXX6zu3btr3rx5ysvL02uvvVZp+1NSUuT1elVYWFhl+84EsV7HynTp0kVOp7PO/7MTbaKplpI0adIkFRUVKT8/X/v379fQoUMlSW3atKm0/ZyTpWK9jpXhnDymLmpZHSkpKRV+TmFhoXw+X5XnF+dkqVivY2U4J4+JVC1r40w8J2M2KF166aX68ssvyy3btm1b6FqSNm3aKCUlRUuXLg2t93q9WrlypXr27ClJOvfcc5WamnrC4/To0UMHDx7URx99FFq/bt06HTx4MHScI0eOKCEhoVyaLntclvytLrroIjmdznLt27Nnj7Zs2RI67pkg1utYma1bt8rn84XezM4U0VTLMjabLTTF6ksvvaS0tLQq/3vJOVkq1utYGc7JY+qiltXRo0cPbdmypdyQySVLlsjlcumiiy6qdB/OyVKxXsfKcE4eE6la1sYZeU6e9ukjwuSjjz4yDofDPPzww2b79u3mn//8p0lOTjb/+Mc/Qts88sgjpmHDhmbBggVm8+bN5rrrrqswxeL//u//mgYNGph///vfZvv27eaPf/yjSUpKKjfL2ZVXXmkuvPBCs3btWrN27Vrzs5/9rNwUtp9//rlxuVzmt7/9rfnss8/Mli1bzK9+9SvTsGFD8+233xpjjNm1a5dp3769WbduXWi/22+/3bRs2dIsW7bMfPrpp6Zv375xPcViZWK9jjt27DBTpkwx69evN3l5eebNN980HTp0MJ07dz6j6mhMdNXSGGMeffRRs2nTJrNlyxYzdepU43Q6zcKFC0PrOScrF+t15Jw85nTW8uuvvzYbNmwwU6ZMMfXq1TMbNmwwGzZsMIcOHTLGHJtWul+/fubTTz81y5YtMy1btiw3rTTnZOVivY6ck8dEUy2NMWb79u1mw4YN5rbbbjPp6emhbUpKSowxnJPGxPD04MYY8/rrr5tOnToZl8tlOnToYJ599tly64PBoHnggQdMSkqKcblcJisry2zevLnCcaZPn25atmxpkpOTTY8ePczq1avLrT9w4IC54YYbTP369U39+vXNDTfcYAoLC8tts2TJEnPppZeahg0bmsaNG5u+ffuatWvXhtbn5eUZSea9994LLfN4POaOO+4wTZo0MW632wwaNKjc1NRniliuY35+vsnKyjJNmjQxiYmJpm3btubOO+80Bw4cCM+LE2OiqZZ9+vQxDRs2NElJSaZbt27mrbfeKreec7JqsVxHzsnyTlctb7rpJiOpwtfx59fXX39trr76auN2u02TJk3MHXfcUe6+L5yTVYvlOnJOlhdNtczOzq50m7y8PGMM56QxxtiMMeY0dV4BAAAAQEyI2WuUAAAAAKCuEJQAAAAAwIKgBAAAAAAWBCUAAAAAsCAoAQAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAC4ISAAAAAFgQlAAAMWv06NGy2Wy6/fbbK6wbO3asbDabRo8eHdp22LBhFfa12WxyOp1q3ry5+vfvr+eff17BYPA0PQMAQLQiKAEAYlpaWppefvlleTye0LKjR4/qpZdeUqtWrU6475VXXqk9e/Zo586devvtt9WnTx9NmDBBgwYNkt/vr+umAwCiGEEJABDTunTpolatWmnBggWhZQsWLFBaWpo6d+58wn1dLpdSUlJ0zjnnqEuXLvrDH/6g1157TW+//bbmzp1bxy0HAEQzghIAIOb9+te/1pw5c0KPn3/+eY0ZM6ZWx+rbt68yMjLKBS8AwJmHoAQAiHk33nij3n//fe3cuVNff/21PvjgA/3qV7+q9fE6dOignTt3hq+BAICY44h0AwAAOFVNmzbV1VdfrRdeeEHGGF199dVq2rRprY9njJHNZgtjCwEAsYagBACIC2PGjNEdd9whSZo1a9YpHevzzz9XmzZtwtEsAECMYugdACAuXHnllfJ6vfJ6vbriiitqfZx3331Xmzdv1siRI8PYOgBArKFHCQAQF+x2uz7//PPQ99VRUlKigoICBQIB7d27V4sXL9b06dM1aNAgjRo1qi6bCwCIcgQlAEDcaNCgQZXrgsGgHI7yf/YWL16sFi1ayOFwqHHjxsrIyNBTTz2lm266SQkJDLoAgDOZzRhjIt0IAADq2pVXXqnzzjtPM2fOjHRTAAAxgH+XAQDiWmFhod58802tWLFCl19+eaSbAwCIEQy9AwDEtTFjxmj9+vW66667NHTo0Eg3BwAQIxh6BwAAAAAWDL0DAAAAAAuCEgAAAABYEJQAAAAAwIKgBAAAAAAWBCUAAAAAsCAoAQAAAIAFQQkAAAAALAhKAAAAAGBBUAIAAAAAi/8PxNNXt/sNF+UAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x1000 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "\n",
     "### 3.3.4 Target zenith angle vs. MJD\n",
@@ -1125,23 +1812,9 @@
     "# Add labels and title\n",
     "plt.xlabel('MJD')\n",
     "plt.ylabel('Zenith Angle')\n",
-    "title = \"\"\"Zenith Angle vs. MJD of %s Observations of Different Science Program Targets on %s\"\"\" %(instrument, day_obs)\n",
+    "title = \"\"\"Zenith Angle vs. MJD of %s Observations of Different Science Program Targets\\n between %s and %s (inclusive)\"\"\" %(instrument, day_obs_start, day_obs_end)\n",
     "plt.title(title)\n",
     "plt.grid(True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c1c4ccc9-25a5-4ddc-853c-01da52b614fd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "# 4. Final cleanup\n",
-    "\n",
-    "# Reset the display.max_rows option to the original default\n",
-    "pd.reset_option(\"display.max_rows\")"
    ]
   },
   {
@@ -1177,7 +1850,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/reports/TargetReport.yaml
+++ b/reports/TargetReport.yaml
@@ -1,30 +1,34 @@
 title: Target Report
 description: List of targets observed.
 parameters:
-  day_obs:
+  day_obs_start:
     type: string
-    description: Observation Night (YYYY-MM-DD)
+    description: Starting Observation Night (YYYY-MM-DD or TODAY)
     default: "2024-08-07"
+  day_obs_end:
+    type: string
+    description: Starting Observation Night (YYYY-MM-DD or TODAY)
+    default: "TODAY"
   instrument:
     type: string
     description: Instrument
-    default: "LATISS"
+    default: "LSSTComCam"
   repo:
     type: string
     description: repo
-    default: "/repo/embargo"
+    default: "embargo_new"
   collection:
     type: string
     description: collection
-    default: "LATISS/prompt/output-2024-08-07"
+    default: "LSSTComCam/nightlyValidation"
   collection_sky:
     type: string
     description: collection for skymap
-    default: "LATISS/runs/AUXTEL_DRP_IMAGING_20230509_20240513/w_2024_20/PREOPS-5146"
+    default: "LSSTComCamSim/runs/DRP/OR4/w_2024_25/DM-45066"
   skymap_name:
     type: string
     description: skymap name
-    default: 'latiss_v1'
+    default: 'ops_rehersal_prep_2k_v1'
   col_sciprog:
     type: string
     description: column name to be used for science program name
@@ -41,4 +45,3 @@ parameters:
     type: string
     description: column name to be used for id
     default: "id"    
-


### PR DESCRIPTION
Updated TargetReport.ipynb to use a range of dates to allow for cumulative statistics.
Also updated TargetReport.yaml for a more ComCam-centric set of defaults.