### PR TITLE
Updated butler timespan date formatting to use cleaner functions.

### DIFF
--- a/reports/TargetReport.ipynb
+++ b/reports/TargetReport.ipynb
@@ -18,11 +18,11 @@
    "id": "3ce8dfcc-d745-4fc3-ad39-6b2d5e0e2be6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:48.322815Z",
-     "iopub.status.busy": "2024-11-05T21:11:48.322693Z",
-     "iopub.status.idle": "2024-11-05T21:11:48.325075Z",
-     "shell.execute_reply": "2024-11-05T21:11:48.324732Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:48.322803Z"
+     "iopub.execute_input": "2024-11-05T22:23:04.584923Z",
+     "iopub.status.busy": "2024-11-05T22:23:04.584808Z",
+     "iopub.status.idle": "2024-11-05T22:23:04.588551Z",
+     "shell.execute_reply": "2024-11-05T22:23:04.588163Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:04.584910Z"
     }
    },
    "outputs": [],
@@ -46,11 +46,11 @@
    "id": "08b3556a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:48.356230Z",
-     "iopub.status.busy": "2024-11-05T21:11:48.355908Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.856813Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.856374Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:48.356212Z"
+     "iopub.execute_input": "2024-11-05T22:23:04.614992Z",
+     "iopub.status.busy": "2024-11-05T22:23:04.614856Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.603405Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.602986Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:04.614980Z"
     },
     "tags": []
    },
@@ -97,11 +97,11 @@
    "id": "0fd9f3fe-be33-4e41-915e-0594018f74c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.857724Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.857582Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.860799Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.860456Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.857711Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.604109Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.603973Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.612198Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.611854Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.604095Z"
     }
    },
    "outputs": [],
@@ -134,11 +134,11 @@
    "id": "2fd7808f-8111-4c23-8735-5a8fbc26b67f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.861334Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.861206Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.868224Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.867881Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.861322Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.612606Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.612483Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.627929Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.627555Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.612593Z"
     }
    },
    "outputs": [],
@@ -186,11 +186,11 @@
    "id": "48629971-c159-4e22-af48-f1a7afb61839",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.868767Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.868639Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.874981Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.874664Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.868755Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.628328Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.628209Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.652310Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.651908Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.628316Z"
     }
    },
    "outputs": [],
@@ -234,11 +234,11 @@
    "id": "7ecfadfc-7a02-4634-a264-cfb4c0e40762",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.876089Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.875930Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.882501Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.882174Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.876077Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.653161Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.653042Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.663126Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.662764Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.653149Z"
     }
    },
    "outputs": [],
@@ -282,11 +282,11 @@
    "id": "b9ef46fb-8f50-49d0-bbae-0a2662baa7d5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.882981Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.882866Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.890532Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.890198Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.882970Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.663497Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.663387Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.674958Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.674608Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.663486Z"
     }
    },
    "outputs": [],
@@ -361,11 +361,11 @@
    "id": "45b41be8-c1e3-428c-9aa2-ab6e2f46afd6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.891068Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.890934Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.896652Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.896299Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.891052Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.675353Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.675240Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.683599Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.683250Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.675340Z"
     }
    },
    "outputs": [],
@@ -397,11 +397,11 @@
    "id": "06739927-d21e-449c-ac6a-89e0118d14ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.897184Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.897062Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.902622Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.902313Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.897173Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.683954Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.683844Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.691837Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.691485Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.683943Z"
     }
    },
    "outputs": [],
@@ -435,11 +435,11 @@
    "id": "fff24f55-6d1c-4f18-9f60-99431c2a5336",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.903138Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.903008Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.908640Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.908316Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.903126Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.692197Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.692088Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.700100Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.699751Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.692186Z"
     }
    },
    "outputs": [],
@@ -469,11 +469,11 @@
    "id": "83b16bb4-cd15-402f-81c2-7b7193df0630",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.909193Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.909072Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.914600Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.914272Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.909182Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.700452Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.700345Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.709987Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.709618Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.700442Z"
     }
    },
    "outputs": [],
@@ -506,11 +506,11 @@
    "id": "c81c9f13-1b9a-4d60-84a8-50368873fb0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.915092Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.914970Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.919722Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.919380Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.915081Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.710931Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.710704Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.718392Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.718042Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.710858Z"
     }
    },
    "outputs": [],
@@ -529,11 +529,11 @@
    "id": "4c6ba6a7-c940-4c0c-a513-f9a4a1dab1b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.920256Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.920138Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.924558Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.924242Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.920245Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.718748Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.718636Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.727396Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.727043Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.718737Z"
     }
    },
    "outputs": [],
@@ -549,11 +549,11 @@
    "id": "07168a2e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.925049Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.924929Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.937308Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.936972Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.925038Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.728131Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.727639Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.769382Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.768990Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.728116Z"
     },
     "tags": []
    },
@@ -570,11 +570,11 @@
    "id": "0bff8f23-c35c-4b72-b9f5-7d32b432ac22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.939110Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.938953Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.941570Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.941239Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.939098Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.770934Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.770815Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.779976Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.779625Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.770922Z"
     }
    },
    "outputs": [],
@@ -596,11 +596,11 @@
    "id": "bab9ef6c-ced2-4d09-b67a-419f1b33d4a8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.942094Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.941966Z",
-     "iopub.status.idle": "2024-11-05T21:11:50.950241Z",
-     "shell.execute_reply": "2024-11-05T21:11:50.949881Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.942082Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.780352Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.780242Z",
+     "iopub.status.idle": "2024-11-05T22:23:08.792191Z",
+     "shell.execute_reply": "2024-11-05T22:23:08.791829Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.780341Z"
     }
    },
    "outputs": [],
@@ -651,11 +651,11 @@
    "id": "81254df0-8ec8-4515-b2dc-743f3cceca16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:50.950798Z",
-     "iopub.status.busy": "2024-11-05T21:11:50.950681Z",
-     "iopub.status.idle": "2024-11-05T21:11:51.416792Z",
-     "shell.execute_reply": "2024-11-05T21:11:51.416380Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:50.950787Z"
+     "iopub.execute_input": "2024-11-05T22:23:08.792556Z",
+     "iopub.status.busy": "2024-11-05T22:23:08.792446Z",
+     "iopub.status.idle": "2024-11-05T22:23:09.391009Z",
+     "shell.execute_reply": "2024-11-05T22:23:09.390629Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:08.792545Z"
     }
    },
    "outputs": [
@@ -702,11 +702,11 @@
    "id": "95d36237-32a9-486b-893a-646ab892ae33",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:51.417419Z",
-     "iopub.status.busy": "2024-11-05T21:11:51.417286Z",
-     "iopub.status.idle": "2024-11-05T21:11:51.434252Z",
-     "shell.execute_reply": "2024-11-05T21:11:51.433912Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:51.417407Z"
+     "iopub.execute_input": "2024-11-05T22:23:09.391453Z",
+     "iopub.status.busy": "2024-11-05T22:23:09.391334Z",
+     "iopub.status.idle": "2024-11-05T22:23:09.414862Z",
+     "shell.execute_reply": "2024-11-05T22:23:09.414497Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:09.391441Z"
     }
    },
    "outputs": [],
@@ -726,11 +726,11 @@
    "id": "0a3d8db3-ca82-450e-bfd9-29bbdf26cdd8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:51.434822Z",
-     "iopub.status.busy": "2024-11-05T21:11:51.434660Z",
-     "iopub.status.idle": "2024-11-05T21:11:51.441846Z",
-     "shell.execute_reply": "2024-11-05T21:11:51.441488Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:51.434810Z"
+     "iopub.execute_input": "2024-11-05T22:23:09.415261Z",
+     "iopub.status.busy": "2024-11-05T22:23:09.415146Z",
+     "iopub.status.idle": "2024-11-05T22:23:09.424638Z",
+     "shell.execute_reply": "2024-11-05T22:23:09.424292Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:09.415250Z"
     }
    },
    "outputs": [
@@ -761,11 +761,11 @@
    "id": "473cdd14",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:51.442411Z",
-     "iopub.status.busy": "2024-11-05T21:11:51.442290Z",
-     "iopub.status.idle": "2024-11-05T21:11:51.445620Z",
-     "shell.execute_reply": "2024-11-05T21:11:51.445286Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:51.442400Z"
+     "iopub.execute_input": "2024-11-05T22:23:09.425001Z",
+     "iopub.status.busy": "2024-11-05T22:23:09.424893Z",
+     "iopub.status.idle": "2024-11-05T22:23:09.431212Z",
+     "shell.execute_reply": "2024-11-05T22:23:09.430861Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:09.424990Z"
     },
     "tags": []
    },
@@ -787,11 +787,11 @@
    "id": "f2c9f07f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:51.446151Z",
-     "iopub.status.busy": "2024-11-05T21:11:51.446024Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.366850Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.366369Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:51.446140Z"
+     "iopub.execute_input": "2024-11-05T22:23:09.431575Z",
+     "iopub.status.busy": "2024-11-05T22:23:09.431466Z",
+     "iopub.status.idle": "2024-11-05T22:23:13.682155Z",
+     "shell.execute_reply": "2024-11-05T22:23:13.681733Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:09.431564Z"
     },
     "tags": []
    },
@@ -802,27 +802,16 @@
     "\n",
     "for count, info in enumerate(results):\n",
     "    \n",
-    "    \n",
     "    try:\n",
-    "        \n",
-    "        info_timespan_begin_jd = info.timespan.begin.jd\n",
-    "        info_timespan_begin_mjd = info_timespan_begin_jd - 2400000.5\n",
-    "        info_timespan_begin = datetime(1858, 11, 17, tzinfo=timezone.utc) + timedelta(info_timespan_begin_mjd)\n",
-    "        info_timespan_begin_to_string = info_timespan_begin.strftime(\"%Y-%m-%d %H:%M:%S.%f\")\n",
-    "        \n",
-    "        info_timespan_end_jd = info.timespan.end.jd\n",
-    "        info_timespan_end_mjd = info_timespan_end_jd - 2400000.5\n",
-    "        info_timespan_end = datetime(1858, 11, 17, tzinfo=timezone.utc) + timedelta(info_timespan_begin_mjd)\n",
-    "        info_timespan_end_to_string = info_timespan_begin.strftime(\"%Y-%m-%d %H:%M:%S.%f\")\n",
     "\n",
     "        df_exp.loc[count] = [info.id, info.obs_id, info.day_obs, info.seq_num, \n",
-    "                                  pd.to_datetime(info_timespan_begin_to_string),\n",
-    "                                  pd.to_datetime(info_timespan_end_to_string), \n",
+    "                                  info.timespan.begin.utc.iso,\n",
+    "                                  info.timespan.end.utc.iso, \n",
     "                                  info.observation_type, info.observation_reason, info.target_name, \n",
     "                                  info.physical_filter, info.zenith_angle, \n",
     "                                  info.exposure_time,info.tracking_ra, info.tracking_dec, \n",
     "                                  info.sky_angle,info.azimuth ,info.zenith_angle, \n",
-    "                                  info.science_program, info_timespan_begin_jd, info_timespan_begin_mjd]\n",
+    "                                  info.science_program, info.timespan.begin.jd, info.timespan.begin.mjd]\n",
     "\n",
     "    except:\n",
     "    \n",
@@ -840,7 +829,7 @@
     "                                  info.sky_angle,info.azimuth ,info.zenith_angle, \n",
     "                                  info.science_program, info_timespan_begin_jd, info_timespan_begin_mjd ]\n",
     " \n",
-    "    \n"
+    "    "
    ]
   },
   {
@@ -849,11 +838,11 @@
    "id": "344a6240-a01b-4876-bc5a-30441b03b5f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.367596Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.367471Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.371691Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.371339Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.367584Z"
+     "iopub.execute_input": "2024-11-05T22:23:13.683901Z",
+     "iopub.status.busy": "2024-11-05T22:23:13.683761Z",
+     "iopub.status.idle": "2024-11-05T22:23:13.704619Z",
+     "shell.execute_reply": "2024-11-05T22:23:13.704214Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:13.683889Z"
     }
    },
    "outputs": [],
@@ -869,11 +858,11 @@
    "id": "9d71ed48-b6ff-43a9-aa91-98e5cd835e3a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.372201Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.372083Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.378820Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.378452Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.372190Z"
+     "iopub.execute_input": "2024-11-05T22:23:13.705147Z",
+     "iopub.status.busy": "2024-11-05T22:23:13.704917Z",
+     "iopub.status.idle": "2024-11-05T22:23:13.735942Z",
+     "shell.execute_reply": "2024-11-05T22:23:13.735342Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:13.705135Z"
     }
    },
    "outputs": [],
@@ -893,11 +882,11 @@
    "id": "4121311c-592e-497a-8eca-8611374087fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.379393Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.379278Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.385640Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.385301Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.379382Z"
+     "iopub.execute_input": "2024-11-05T22:23:13.736399Z",
+     "iopub.status.busy": "2024-11-05T22:23:13.736278Z",
+     "iopub.status.idle": "2024-11-05T22:23:13.773606Z",
+     "shell.execute_reply": "2024-11-05T22:23:13.773004Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:13.736387Z"
     }
    },
    "outputs": [],
@@ -915,11 +904,11 @@
    "id": "17ef1097-23b6-482a-9560-d55e38d3fa3e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.386191Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.386068Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.413411Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.413051Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.386180Z"
+     "iopub.execute_input": "2024-11-05T22:23:13.774081Z",
+     "iopub.status.busy": "2024-11-05T22:23:13.773954Z",
+     "iopub.status.idle": "2024-11-05T22:23:13.846410Z",
+     "shell.execute_reply": "2024-11-05T22:23:13.845812Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:13.774068Z"
     }
    },
    "outputs": [],
@@ -962,11 +951,11 @@
    "id": "9e52043b-a9ee-402d-8ad8-20887e1e2f73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.413972Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.413848Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.775928Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.775497Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.413960Z"
+     "iopub.execute_input": "2024-11-05T22:23:13.846853Z",
+     "iopub.status.busy": "2024-11-05T22:23:13.846736Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.530202Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.529802Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:13.846841Z"
     }
    },
    "outputs": [],
@@ -991,11 +980,11 @@
    "id": "2aeeed89-d52d-4da4-bff6-a07fa875bcf7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.776605Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.776438Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.779391Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.779052Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.776591Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.530674Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.530545Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.535859Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.535490Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.530662Z"
     }
    },
    "outputs": [],
@@ -1011,11 +1000,11 @@
    "id": "a90fa41a-7ac4-4236-9d77-d747052a37d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.779979Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.779835Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.785759Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.785437Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.779967Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.536259Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.536144Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.548314Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.547929Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.536247Z"
     }
    },
    "outputs": [],
@@ -1037,11 +1026,11 @@
    "id": "6b93a02d-e5b4-4cc3-b7aa-2aa423c29b4e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.786307Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.786192Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.793568Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.793230Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.786296Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.548701Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.548589Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.559915Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.559572Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.548690Z"
     }
    },
    "outputs": [],
@@ -1064,11 +1053,11 @@
    "id": "cb6fd38f-14af-4799-8916-b91a2af3b1f3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.794139Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.793988Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.801643Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.801291Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.794125Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.560307Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.560194Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.583980Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.583583Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.560296Z"
     }
    },
    "outputs": [],
@@ -1091,11 +1080,11 @@
    "id": "cb209d08-c012-44c7-a6a9-537cce2f4ec9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.802264Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.802118Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.805136Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.804807Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.802252Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.584388Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.584274Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.594243Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.593894Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.584376Z"
     }
    },
    "outputs": [],
@@ -1120,11 +1109,11 @@
    "id": "fe11f6f4-deed-41de-ba13-12fd11936fe5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.805700Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.805585Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.816333Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.816008Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.805689Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.594603Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.594495Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.608246Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.607880Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.594593Z"
     }
    },
    "outputs": [
@@ -1282,11 +1271,11 @@
    "id": "acfd31b2-8e59-4902-b1a1-e190555661cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.816902Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.816757Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.822288Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.821956Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.816891Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.608610Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.608501Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.619478Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.619137Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.608599Z"
     }
    },
    "outputs": [],
@@ -1304,11 +1293,11 @@
    "id": "7ac007d6-5b1e-4fb6-b5d3-494720c72b0c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.822812Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.822671Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.827482Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.827159Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.822800Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.619836Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.619725Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.629834Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.629478Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.619825Z"
     }
    },
    "outputs": [],
@@ -1328,11 +1317,11 @@
    "id": "889ddab3-3d6d-4189-8366-9be53a228ee0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.828050Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.827902Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.835641Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.835290Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.828038Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.630195Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.630081Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.651134Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.649637Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.630184Z"
     }
    },
    "outputs": [],
@@ -1350,11 +1339,11 @@
    "id": "75449f39-3e82-487e-b7d5-a74924dd4ddc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.836154Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.836000Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.840356Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.840048Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.836143Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.651521Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.651409Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.662729Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.662392Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.651510Z"
     }
    },
    "outputs": [],
@@ -1371,11 +1360,11 @@
    "id": "aa15ef48-cca4-4727-9efc-08f3e4d500dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.840936Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.840796Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.853374Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.853051Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.840924Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.663101Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.662980Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.685153Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.684788Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.663088Z"
     }
    },
    "outputs": [],
@@ -1413,11 +1402,11 @@
    "id": "4558e507-a828-4836-8e06-686217138a7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.853972Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.853826Z",
-     "iopub.status.idle": "2024-11-05T21:11:55.863485Z",
-     "shell.execute_reply": "2024-11-05T21:11:55.863166Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.853961Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.685521Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.685407Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.698396Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.698049Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.685510Z"
     }
    },
    "outputs": [
@@ -1636,11 +1625,11 @@
    "id": "3a255c90-e086-4bf4-8796-fdfd7b08f8aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:55.864117Z",
-     "iopub.status.busy": "2024-11-05T21:11:55.863969Z",
-     "iopub.status.idle": "2024-11-05T21:11:56.025969Z",
-     "shell.execute_reply": "2024-11-05T21:11:56.025505Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:55.864105Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.698753Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.698644Z",
+     "iopub.status.idle": "2024-11-05T22:23:14.932610Z",
+     "shell.execute_reply": "2024-11-05T22:23:14.932262Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.698742Z"
     }
    },
    "outputs": [
@@ -1701,11 +1690,11 @@
    "id": "c34cf1ba-4e0d-429f-8d9b-52fa29f08658",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:56.026639Z",
-     "iopub.status.busy": "2024-11-05T21:11:56.026506Z",
-     "iopub.status.idle": "2024-11-05T21:11:56.153647Z",
-     "shell.execute_reply": "2024-11-05T21:11:56.153219Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:56.026627Z"
+     "iopub.execute_input": "2024-11-05T22:23:14.933052Z",
+     "iopub.status.busy": "2024-11-05T22:23:14.932925Z",
+     "iopub.status.idle": "2024-11-05T22:23:15.076416Z",
+     "shell.execute_reply": "2024-11-05T22:23:15.076010Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:14.933040Z"
     }
    },
    "outputs": [
@@ -1750,11 +1739,11 @@
    "id": "1d4139ce-9cd4-47d9-8288-681db988dcc4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:56.154256Z",
-     "iopub.status.busy": "2024-11-05T21:11:56.154126Z",
-     "iopub.status.idle": "2024-11-05T21:11:56.271196Z",
-     "shell.execute_reply": "2024-11-05T21:11:56.270855Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:56.154245Z"
+     "iopub.execute_input": "2024-11-05T22:23:15.076866Z",
+     "iopub.status.busy": "2024-11-05T22:23:15.076745Z",
+     "iopub.status.idle": "2024-11-05T22:23:15.255006Z",
+     "shell.execute_reply": "2024-11-05T22:23:15.254401Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:15.076853Z"
     }
    },
    "outputs": [
@@ -1801,11 +1790,11 @@
    "id": "c1c4ccc9-25a5-4ddc-853c-01da52b614fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:56.273646Z",
-     "iopub.status.busy": "2024-11-05T21:11:56.273520Z",
-     "iopub.status.idle": "2024-11-05T21:11:56.275608Z",
-     "shell.execute_reply": "2024-11-05T21:11:56.275265Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:56.273634Z"
+     "iopub.execute_input": "2024-11-05T22:23:15.257221Z",
+     "iopub.status.busy": "2024-11-05T22:23:15.257095Z",
+     "iopub.status.idle": "2024-11-05T22:23:15.264483Z",
+     "shell.execute_reply": "2024-11-05T22:23:15.264118Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:15.257209Z"
     }
    },
    "outputs": [],
@@ -1823,11 +1812,11 @@
    "id": "3d2d7e9a-a8c5-43e3-9fb3-f8b7cf5b6e87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2024-11-05T21:11:56.276229Z",
-     "iopub.status.busy": "2024-11-05T21:11:56.276110Z",
-     "iopub.status.idle": "2024-11-05T21:11:56.436749Z",
-     "shell.execute_reply": "2024-11-05T21:11:56.436386Z",
-     "shell.execute_reply.started": "2024-11-05T21:11:56.276218Z"
+     "iopub.execute_input": "2024-11-05T22:23:15.264851Z",
+     "iopub.status.busy": "2024-11-05T22:23:15.264736Z",
+     "iopub.status.idle": "2024-11-05T22:23:15.497322Z",
+     "shell.execute_reply": "2024-11-05T22:23:15.496958Z",
+     "shell.execute_reply.started": "2024-11-05T22:23:15.264839Z"
     }
    },
    "outputs": [


### PR DESCRIPTION
Now using `info.timespan.begin.utc.iso`, `info.timespan.end.utc.iso`, `info.timespan.begin.jd`, `info.timespan.begin.mjd`, following a suggestion by @timj .  thanks, @timj !